### PR TITLE
fix: unmatching optimization profiles with TensorRT-LLM

### DIFF
--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -142,4 +142,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     @computed_field  # type: ignore[prop-decorator]
     @property
     def cache_indirection(self) -> TensorTypeHint:
-        return TensorTypeHint(shape=(self.batch_size, self.beam_width, self.attention_window_size), dtype=torch.int32)
+        return TensorTypeHint(
+            shape=(self.batch_size, self.beam_width, self.attention_window_size),
+            dtype=torch.int32,
+        )

--- a/src/ditto/configs/trtllm/literals.py
+++ b/src/ditto/configs/trtllm/literals.py
@@ -17,7 +17,7 @@ KVCacheTypeLiteral = Literal["CONTINUOUS", "DISABLED", "PAGED"]
 
 LoraCheckpointLiteral = Literal["hf", "nemo"]
 
-PluginFlag = Literal["auto", None]
+PluginFlag = Literal["auto", "float16", "bfloat16", "fp8", None]
 
 QuantAlgoLiteral = Literal[
     "W8A16",

--- a/src/ditto/configs/trtllm/plugin.py
+++ b/src/ditto/configs/trtllm/plugin.py
@@ -4,6 +4,7 @@ from .literals import PluginFlag
 
 class TRTLLMPluginConfig(StrictlyTyped):
     gpt_attention_plugin: PluginFlag = "auto"
+    gemm_plugin: PluginFlag = "auto"
     lora_plugin: PluginFlag = None
     mamba_conv1d_plugin: PluginFlag = "auto"
     context_fmha: bool = True


### PR DESCRIPTION
- Fix unmatching optimization profiles.
  - `max_batch_size`, `max_attention_window_size` are set to `max_position_embeddings`.
  - `max_kv_cache_block_size` and `opt_kv_cache_block_size` are calculated using `tokens_per_block`(default: 64).
  - The value of `opt_num_tokens` is determined as the minimum between `max_num_tokens` and `max_batch_size * max_beam_width`.
- Minor update
  - add `gemm_plugin` to `TRTLLMPluginConfig` class.