### PR TITLE
[FOC-689] Support EXAONE

### DIFF
--- a/src/ditto/__main__.py
+++ b/src/ditto/__main__.py
@@ -14,6 +14,7 @@ from typer import Option, Typer
 
 from .api import trtllm_build
 from .constants import DEFAULT_DEVICE, DISABLE_TRANSFORMER_PATCHES
+from .contexts import disable_torch_jit_state
 from .types import trt_to_torch_dtype_mapping
 
 if not DISABLE_TRANSFORMER_PATCHES:
@@ -94,16 +95,16 @@ def build(
     run_matmuls_in_fp32: bool = True,
     run_activations_in_model_dtype: bool = True,
 ) -> None:
-    logger.info("torch.jit.script disabled")
     output_dir = resolve_output_dir(output_dir, model_id)
     app.pretty_exceptions_show_locals = verbose
 
-    model = AutoModelForCausalLM.from_pretrained(
-        model_id,
-        torch_dtype=get_model_dtype(dtype),
-        device_map=device,
-        trust_remote_code=trust_remote_code,
-    )
+    with disable_torch_jit_state():
+        model = AutoModelForCausalLM.from_pretrained(
+            model_id,
+            torch_dtype=get_model_dtype(dtype),
+            device_map=device,
+            trust_remote_code=trust_remote_code,
+        )
     logger.info(f"device: {device} | dtype: {model.config.torch_dtype}")
 
     engine, config = trtllm_build(

--- a/src/ditto/contexts.py
+++ b/src/ditto/contexts.py
@@ -5,6 +5,7 @@ from typing import Any
 
 import torch
 import torch.jit._state as torch_jit_state
+from loguru import logger
 from torch.fx.experimental.sym_node import SymNode
 from torch.fx.experimental.symbolic_shapes import log as symbolic_shape_logger
 
@@ -52,8 +53,10 @@ def ignore_symbolic_shapes_warning() -> Generator[None, None, None]:
 def disable_torch_jit_state() -> Generator[None, None, None]:
     if was_enabled := torch_jit_state._enabled.enabled:
         torch_jit_state.disable()
+        logger.info("torch.jit.script disabled")
     try:
         yield None
     finally:
         if was_enabled:
             torch_jit_state.enable()
+            logger.info("torch.jit.script enabled")

--- a/src/ditto/export.py
+++ b/src/ditto/export.py
@@ -6,7 +6,6 @@ from torch.nn.attention import sdpa_kernel
 from transformers import PreTrainedModel
 
 from .arguments.torch_export_arguments import TorchExportArguments
-from .contexts import disable_torch_jit_state
 from .types import BuiltInConstant, SDPBackend
 
 
@@ -24,7 +23,7 @@ def export(
             "`torch.nn.functional.scaled_dot_product_attention`."
         )
 
-    with sdpa_kernel(sdp_backends), disable_torch_jit_state():
+    with sdpa_kernel(sdp_backends):
         exported_program = torch_export(
             ConstantInputFilterer(model, constant_inputs=arguments.constant_inputs),
             args=(),


### PR DESCRIPTION
# Changes

The implementation of EXAONE has a function with `torch.jit.script` decoration. This causes an error due to dynamic dimensions. So, it needs to disable `torch.jit.script`.

- [add: disable torch.jit.script](https://github.com/SqueezeBits/ditto/pull/18/commits/b60c8075f62ad73ca113e0d4b93655731adecf9c)