### PR TITLE
fix: correct misleaded import style

### DIFF
--- a/src/ditto/fx/passes/wrap_rope_subgraphs.py
+++ b/src/ditto/fx/passes/wrap_rope_subgraphs.py
@@ -1,6 +1,5 @@
 from loguru import logger
 from torch.fx import Node
-
 from transformers import PretrainedConfig
 
 from ..subgraphs import RoPESubgraph

--- a/src/ditto/fx/targets/rope.py
+++ b/src/ditto/fx/targets/rope.py
@@ -2,7 +2,6 @@ from collections.abc import Callable
 
 import torch
 from tensorrt_llm.functional import PositionEmbeddingType
-
 from transformers.models.cohere.modeling_cohere import rotate_half as rotate_half_gptj
 from transformers.models.llama.modeling_llama import rotate_half as rotate_half_gpt_neox
 


### PR DESCRIPTION
Regarding the ruff issue, it turned out my setting was misleading because of symbolic-linked transformers directory on the path. Sorry😅 Correcting the relevant parts from my previous PR.