### PR TITLE
hotfix: bias tensor parallelism to handle for Q, K, and V biases in linear layers

### DIFF
--- a/src/ditto/transform.py
+++ b/src/ditto/transform.py
@@ -108,7 +108,7 @@ def parallelize(
         for rank in range(mapping.world_size):
             logger.debug(f"Running parallelize passes for rank {rank}")
             sub_graph_module = GraphModule(state_dict, deepcopy(graph_module.graph))
-            # WIP: add parallelize graph module
+            sub_graph_module.meta.update(graph_module.meta)
             parallelize_pass_manager = DynamoPassManager.build_from_passlist(
                 [
                     ParallelizeTensor(mapping=mapping.copy_with_rank(rank)).as_transform(),


### PR DESCRIPTION
- Fixed for bias tensor parallelism to handle Q, K, and V biases for building Qwen2 model.
- Updated `generate_config` to scale attention and key-value heads by `mapping.tp_size`.
- Modified `parallelize` funciton to make sub-graph module having a proper metadata.