### PR TITLE
fix: align engine input ordering

### DIFF
--- a/src/ditto/arguments/tensor_type_hint.py
+++ b/src/ditto/arguments/tensor_type_hint.py
@@ -32,7 +32,9 @@ class TensorTypeHint(StrictlyTyped):
 
     def as_spec(self, name: str) -> Input:
         if self.shape == (int_shape := tuple(s for s in self.shape if isinstance(s, int))):
-            return Input.from_tensor(torch.zeros(int_shape, dtype=self.dtype))
+            spec = Input.from_tensor(torch.zeros(int_shape, dtype=self.dtype))
+            spec.name = name
+            return spec
         min_shape = tuple(s if isinstance(s, int) else s.min for s in self.shape)
         min_shape = tuple(max(1, s) for s in min_shape)
         opt_shape = tuple(s if isinstance(s, int) else s.opt for s in self.shape)

--- a/src/ditto/convert.py
+++ b/src/ditto/convert.py
@@ -48,6 +48,9 @@ def convert(
     )
     logger.opt(lazy=True).debug("input_specs:\n{x}", x=lambda: "\n".join(str(spec) for spec in input_specs))
 
+    assert len(placeholders := graph_module.graph.find_nodes(op="placeholder")) == len(input_specs)
+    assert all(p.name == i.name for p, i in zip(placeholders, input_specs))
+
     try:
         interpreter = TRTLLMInterpreter(
             graph_module,


### PR DESCRIPTION
revert some changes in argument hint to enforce same ordering in argument_hint.as_dict() and graphmodule placeholders (especially input_ids), and added some safety checks to ease the debugging next time when we get into this kind of issues again