### PR TITLE
fix: improve handling optimization profiles

### DIFF
--- a/src/ditto/arguments/dynamic_dim.py
+++ b/src/ditto/arguments/dynamic_dim.py
@@ -76,12 +76,14 @@ class DynamicDimensionType(BaseModel, ABC):
         return self
 
     @property
-    def sym_int(self) -> torch.SymInt:
+    def sym_int(self) -> torch.SymInt | int:
         """Get the symbolic integer of the dynamic dimension.
 
         Returns:
-            torch.SymInt: The symbolic integer of the dynamic dimension
+            torch.SymInt | int: The symbolic integer or integer of the dynamic dimension
         """
+        if self.min == self.max:
+            return self.opt
         if self._sym_int is None:
             self._sym_int = self._create_sym_int()
         return self._sym_int
@@ -311,7 +313,8 @@ class DynamicDimension(DynamicDimensionType):
         Returns:
             int: The example value of the dynamic dimension
         """
-        ex = min(max(self.opt, 2), self.max) if self.given_example is None else self.given_example
+        mid = (self.min + self.max) // 2
+        ex = min(max(mid, 2), self.max) if self.given_example is None else self.given_example
         if ex < 2 and self.min < self.max:
             the_example_size = (
                 "the inferred example size" if self.given_example is None else "the provided example size"

--- a/src/ditto/arguments/dynamic_dim.py
+++ b/src/ditto/arguments/dynamic_dim.py
@@ -30,7 +30,7 @@ from torch.utils._sympy.value_ranges import ValueRanges
 from typing_extensions import Self
 
 from ..contexts import detailed_sym_node_str
-from ..types import ExportDim
+from ..types import ExportDim, SymbolicInteger
 
 
 class DynamicDimensionCacheConflictError(RuntimeError):
@@ -76,11 +76,11 @@ class DynamicDimensionType(BaseModel, ABC):
         return self
 
     @property
-    def sym_int(self) -> torch.SymInt | int:
+    def sym_int(self) -> SymbolicInteger:
         """Get the symbolic integer of the dynamic dimension.
 
         Returns:
-            torch.SymInt | int: The symbolic integer or integer of the dynamic dimension
+            SymbolicInteger: The symbolic integer of the dynamic dimension
         """
         if self.min == self.max:
             return self.opt

--- a/src/ditto/arguments/torch_export_arguments.py
+++ b/src/ditto/arguments/torch_export_arguments.py
@@ -94,6 +94,9 @@ class TorchExportArguments(StrictlyTyped):
                     continue
                 assert (constraint := constraints[name]) is not None
                 if not isinstance(export_dim := s.export_dim, int):
+                    # Note: The reason for multiplying by 2 is to satisfy the constraint
+                    # imposed by some layers in `torch.export` (e.g., torch.split).
+                    # This scale factor may be adjusted in the future if additional constraints arise.
                     constraint[dim] = 2 * export_dim
 
             if not constraints[name]:

--- a/src/ditto/arguments/torch_export_arguments.py
+++ b/src/ditto/arguments/torch_export_arguments.py
@@ -94,7 +94,7 @@ class TorchExportArguments(StrictlyTyped):
                     continue
                 assert (constraint := constraints[name]) is not None
                 if not isinstance(export_dim := s.export_dim, int):
-                    constraint[dim] = export_dim
+                    constraint[dim] = 2 * export_dim
 
             if not constraints[name]:
                 constraints[name] = None

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -85,15 +85,12 @@ class TRTLLMArgumentHint(StrictlyTyped):
             opt=profile_config.opt_seq_len,
             max=profile_config.max_seq_len,
         )
-        s = DynamicDimension(
+        num_tokens = DynamicDimension(
             name="num_tokens",
             min=1,
-            opt=profile_config.opt_num_tokens // 2 if profile_config.opt_num_tokens > 1 else 1,
-            max=profile_config.max_num_tokens // 2,
+            opt=profile_config.opt_num_tokens,
+            max=profile_config.max_num_tokens,
         )
-        num_tokens = 2 * s
-        num_tokens.min = 1
-        num_tokens.opt = num_tokens.opt if num_tokens.opt > 1 else 1
         max_blocks_per_seq = DynamicDimension(
             name="max_blocks_per_seq",
             min=1,

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -86,11 +86,12 @@ class TRTLLMArgumentHint(StrictlyTyped):
         s = DynamicDimension(
             name="num_tokens",
             min=1,
-            opt=profile_config.opt_num_tokens // 2,
+            opt=profile_config.opt_num_tokens // 2 if profile_config.opt_num_tokens > 1 else 1,
             max=profile_config.max_num_tokens // 2,
         )
         num_tokens = 2 * s
         num_tokens.min = 1
+        num_tokens.opt = num_tokens.opt if num_tokens.opt > 1 else 1
         max_blocks_per_seq = DynamicDimension(
             name="max_blocks_per_seq",
             min=1,

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -18,7 +18,7 @@
 from collections.abc import Callable
 
 import torch
-from pydantic import Field, TypeAdapter, computed_field, model_serializer
+from pydantic import Field, PrivateAttr, TypeAdapter, computed_field, model_serializer
 from typing_extensions import Self
 
 from ..configs import TRTLLMOptimizationProfileConfig
@@ -53,6 +53,8 @@ class TRTLLMArgumentHint(StrictlyTyped):
     tp_size: int = Field(default=1, exclude=True, gt=0)
     gather_context_logits: bool = Field(default=False, exclude=True)
     lora_input_hints: dict[str, TensorTypeHint] = Field(default_factory=dict, exclude=True)
+    _one: DynamicDimension = PrivateAttr(default=DynamicDimension(name="one", min=1, opt=1, max=1))
+    _two: DynamicDimension = PrivateAttr(default=DynamicDimension(name="two", min=2, opt=2, max=2))
 
     @classmethod
     def configure(
@@ -126,6 +128,23 @@ class TRTLLMArgumentHint(StrictlyTyped):
         """
         return TypeAdapter(dict[str, TensorTypeHint | None]).validate_python(self.model_dump())
 
+    def create_dynamic_dim(self, name: str, ranges: list[int]) -> DynamicDimension:
+        """Create a dynamic dimension.
+
+        Args:
+            name (str): The name of the dynamic dimension
+            ranges (list[int]): The ranges of the dynamic dimension
+
+        Returns:
+            DynamicDimension: The created dynamic dimension
+        """
+        assert len(ranges) == 1 or len(ranges) == 3, "ranges must be a list of one or three integers"
+        if len(ranges) == 1:
+            dim_range = (ranges[0], ranges[0], ranges[0])
+        else:
+            dim_range = (ranges[0], ranges[1], ranges[2])
+        return DynamicDimension(name=name, min=dim_range[0], opt=dim_range[2], max=dim_range[1])
+
     @property
     def batched_input_ids(self) -> TensorTypeHint:
         """Tensor type hint for batched input IDs with shape (1, num_tokens) or (num_tokens, 1)."""
@@ -169,7 +188,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     @property
     def host_kv_cache_pool_pointers(self) -> TensorTypeHint:
         """Tensor type hint for host KV cache pool pointers with shape (1, 2)."""
-        return TensorTypeHint(shape=(1, 2), dtype=torch.int64)
+        return TensorTypeHint(shape=(self._one, 2), dtype=torch.int64)
 
     @computed_field
     @property
@@ -199,7 +218,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     @property
     def host_runtime_perf_knobs(self) -> TensorTypeHint:
         """Tensor type hint for host runtime performance knobs with shape (16,)."""
-        return TensorTypeHint(shape=(16,), dtype=torch.int64)
+        return TensorTypeHint(shape=(self.create_dynamic_dim("host_runtime_perf_knobs", [16]),), dtype=torch.int64)
 
     @computed_field
     @property
@@ -212,13 +231,16 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_max_attention_window_sizes(self) -> TensorTypeHint:
         """Tensor type hint for host max attention window sizes with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_max_attention_window_sizes"
-        return TensorTypeHint(shape=(self.num_attn_layers,), dtype=torch.int32)
+        return TensorTypeHint(
+            shape=(self.create_dynamic_dim("host_max_attention_window_sizes", [self.num_attn_layers]),),
+            dtype=torch.int32,
+        )
 
     @computed_field
     @property
     def host_sink_token_length(self) -> TensorTypeHint:
         """Tensor type hint for host sink token length with shape (1,)."""
-        return TensorTypeHint(shape=(1,), dtype=torch.int32)
+        return TensorTypeHint(shape=(self._one,), dtype=torch.int32)
 
     @computed_field
     @property
@@ -234,13 +256,16 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_kv_cache_pool_mapping(self) -> TensorTypeHint:
         """Tensor type hint for host KV cache pool mapping with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_kv_cache_pool_mapping"
-        return TensorTypeHint(shape=(self.num_attn_layers,), dtype=torch.int32)
+        return TensorTypeHint(
+            shape=(self.create_dynamic_dim("host_max_attention_window_sizes", [self.num_attn_layers]),),
+            dtype=torch.int32,
+        )
 
     @computed_field
     @property
     def host_context_progress(self) -> TensorTypeHint:
         """Tensor type hint for host context progress with shape (1,)."""
-        return TensorTypeHint(shape=(1,), dtype=torch.int64)
+        return TensorTypeHint(shape=(self._one,), dtype=torch.int64)
 
     @computed_field
     @property

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -85,11 +85,12 @@ class TRTLLMArgumentHint(StrictlyTyped):
         )
         s = DynamicDimension(
             name="num_tokens",
-            min=0,
-            opt=profile_config.opt_num_tokens // 8,
-            max=profile_config.max_num_tokens // 8,
+            min=1,
+            opt=profile_config.opt_num_tokens // 2,
+            max=profile_config.max_num_tokens // 2,
         )
-        num_tokens = 8 * s
+        num_tokens = 2 * s
+        num_tokens.min = 1
         max_blocks_per_seq = DynamicDimension(
             name="max_blocks_per_seq",
             min=1,

--- a/src/ditto/configs/trtllm/optimization_profile.py
+++ b/src/ditto/configs/trtllm/optimization_profile.py
@@ -32,7 +32,7 @@ class RuntimeTRTLLMOptimizationProfileConfig(StrictlyTyped):
     opt_batch_size: int = Field(default=128, gt=0)
     max_batch_size: int = Field(default=256, gt=0)
     max_beam_width: int = Field(default=1, gt=0)
-    max_num_tokens: int = Field(default=8192, multiple_of=2, gt=0)
+    max_num_tokens: int = Field(default=8192, gt=0)
     opt_num_tokens: int = Field(default=8, gt=0)
 
     @model_validator(mode="after")

--- a/src/ditto/configs/trtllm/optimization_profile.py
+++ b/src/ditto/configs/trtllm/optimization_profile.py
@@ -32,8 +32,8 @@ class RuntimeTRTLLMOptimizationProfileConfig(StrictlyTyped):
     opt_batch_size: int = Field(default=128, gt=0)
     max_batch_size: int = Field(default=256, gt=1)
     max_beam_width: int = Field(default=1, gt=0)
-    max_num_tokens: int = Field(default=8192, multiple_of=8, gt=1)
-    opt_num_tokens: int = Field(default=8, multiple_of=8, gt=0)
+    max_num_tokens: int = Field(default=8192, multiple_of=2, gt=1)
+    opt_num_tokens: int = Field(default=8, multiple_of=2, gt=0)
 
     @model_validator(mode="after")
     def check_runtime_attribute_dependencies(self) -> Self:

--- a/src/ditto/configs/trtllm/optimization_profile.py
+++ b/src/ditto/configs/trtllm/optimization_profile.py
@@ -27,12 +27,12 @@ from .plugin import TRTLLMPluginConfig
 class RuntimeTRTLLMOptimizationProfileConfig(StrictlyTyped):
     """A subset of properties in `trtllm.BuildConfig` related to optimization profile required at runtime."""
 
-    max_input_len: int = Field(default=1024, gt=1)
-    max_seq_len: int = Field(default=DEFAULT_MAX_POS_EMBEDDING, gt=1)
+    max_input_len: int = Field(default=1024, gt=0)
+    max_seq_len: int = Field(default=DEFAULT_MAX_POS_EMBEDDING, gt=0)
     opt_batch_size: int = Field(default=128, gt=0)
     max_batch_size: int = Field(default=256, gt=0)
     max_beam_width: int = Field(default=1, gt=0)
-    max_num_tokens: int = Field(default=8192, multiple_of=2, gt=1)
+    max_num_tokens: int = Field(default=8192, multiple_of=2, gt=0)
     opt_num_tokens: int = Field(default=8, gt=0)
 
     @model_validator(mode="after")

--- a/src/ditto/configs/trtllm/optimization_profile.py
+++ b/src/ditto/configs/trtllm/optimization_profile.py
@@ -100,12 +100,6 @@ class TRTLLMOptimizationProfileConfig(RuntimeTRTLLMOptimizationProfileConfig):
         Returns:
             TRTLLMOptimizationProfileConfig: The optimization profile configuration
         """
-
-        def divide_by_2(value: int, *, offset: int = 0) -> int:
-            if (ret := (value + offset) // 2) == 0:
-                return 1
-            return ret
-
         max_position_embeddings = getattr(hf_config, "max_position_embeddings", DEFAULT_MAX_POS_EMBEDDING)
         rope_scaling = getattr(hf_config, "rope_scaling", None)
         if rope_scaling is not None:
@@ -124,17 +118,17 @@ class TRTLLMOptimizationProfileConfig(RuntimeTRTLLMOptimizationProfileConfig):
             opt_num_tokens = min(max_num_tokens, max_batch_size * max_beam_width)
             logger.debug(f"opt_num_tokens is not set, specifying to {opt_num_tokens}")
         max_kv_cache_block_size = math.ceil(max_seq_len / plugin_config.tokens_per_block)
-        opt_kv_cache_block_size = math.ceil(divide_by_2(max_seq_len) / plugin_config.tokens_per_block)
+        opt_kv_cache_block_size = math.ceil((max_seq_len // 2) / plugin_config.tokens_per_block)
         return cls(
             max_batch_size=max_batch_size,
-            opt_batch_size=divide_by_2(max_batch_size, offset=1),
+            opt_batch_size=max(1, (max_batch_size + 1) // 2),
             max_seq_len=max_seq_len,
-            opt_seq_len=divide_by_2(max_seq_len, offset=1),
+            opt_seq_len=max(1, (max_seq_len + 1) // 2),
             max_input_len=max_input_len,
             max_num_tokens=max_num_tokens,
             opt_num_tokens=opt_num_tokens,
             max_beam_width=max_beam_width,
-            opt_beam_width=divide_by_2(max_beam_width, offset=1),
+            opt_beam_width=max(1, (max_beam_width + 1) // 2),
             max_kv_cache_block_size=max_kv_cache_block_size,
             opt_kv_cache_block_size=opt_kv_cache_block_size,
         )

--- a/src/ditto/debug/engine.py
+++ b/src/ditto/debug/engine.py
@@ -499,6 +499,7 @@ def get_shape_ranges(
                 )
             )
             for name in input_names
+            if name not in ("logits",)
         }
         for profile in optimization_profiles
     ]


### PR DESCRIPTION
- Remove the constraint on multiples of 2 or 8 for dynamic dimensions
- Support the dynamic dimensions with the same min and max values

Note: Some constants of dynamic dimensions are not instances of `DynamicDimension`, but simply `Number`. These values might be updated in the future as new features are added.