### PR TITLE
[FOC-763] feat: support pipeline parallelism

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -35,6 +35,13 @@ main() {
         "Qwen/Qwen2-7B-Instruct --tp-size 2"
         "microsoft/phi-4 --tp-size 2"
         "CohereForAI/aya-expanse-8b --model-type commandr --tp-size 2"
+        # PP
+        "meta-llama/Llama-3.1-8B-Instruct --pp-size 2"
+        "mistralai/Mistral-7B-Instruct-v0.3 --model-type llama --pp-size 2"
+        # "google/gemma-2-9b-it --pp-size 2" # unsupported in TensorRT-LLM
+        "Qwen/Qwen2-7B-Instruct --pp-size 2"
+        # "microsoft/phi-4 --pp-size 2" # unsupported in TensorRT-LLM
+        # "CohereForAI/aya-expanse-8b --model-type commandr --pp-size 2" # unsupported in TensorRT-LLM
     )
 
     for MODEL_SPECIFIC_ARG in "${MODEL_SPECIFIC_ARGS[@]}"; do

--- a/src/ditto/__main__.py
+++ b/src/ditto/__main__.py
@@ -31,7 +31,6 @@ from transformers import (
 from typer import Argument, Option, Typer
 
 from .api import trtllm_build
-from .configs import TRTLLMMapping
 from .constants import DEFAULT_DEVICE
 from .contexts import disable_modelopt_peft_patches, disable_torch_jit_state
 from .literals import DTypeLiteral
@@ -214,7 +213,6 @@ def build(
     trtllm_build(
         model,
         output_dir,
-        mapping=TRTLLMMapping(pp_size=pp_size, tp_size=tp_size),
         run_matmuls_in_fp32=run_matmuls_in_fp32,
         run_activations_in_model_dtype=run_activations_in_model_dtype,
         debug_node_names=add_output,
@@ -223,6 +221,8 @@ def build(
         max_num_tokens=max_num_tokens,
         opt_num_tokens=opt_num_tokens,
         max_beam_width=max_beam_width,
+        pp_size=pp_size,
+        tp_size=tp_size,
         logits_dtype=logits_dtype,
         gather_context_logits=gather_context_logits,
         gather_generation_logits=gather_generation_logits,

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -21,7 +21,7 @@ import torch
 from pydantic import Field, PrivateAttr, TypeAdapter, computed_field, model_serializer
 from typing_extensions import Self
 
-from ..configs import TRTLLMOptimizationProfileConfig
+from ..configs import TRTLLMMapping, TRTLLMOptimizationProfileConfig
 from ..constants import INPUT_IDS_UNSQUEEZE_DIM
 from ..types import StrictlyTyped
 from .dynamic_dim import DynamicDimension, DynamicDimensionType
@@ -38,10 +38,12 @@ class TRTLLMArgumentHint(StrictlyTyped):
         num_tokens (DynamicDimensionType): Number of tokens dimension
         max_blocks_per_seq (DynamicDimensionType): Maximum number of blocks per sequence dimension
         beam_width (DynamicDimensionType | int): Beam width dimension or fixed value
+        mapping (TRTLLMMapping): Mapping configuration
         num_attn_layers (int | None): Number of attention layers. Defaults to None.
-        tp_size (int): Tensor parallel size. Defaults to 1.
         gather_context_logits (bool): Whether to gather context logits. Defaults to False.
         lora_input_hints (dict[str, TensorTypeHint]): LoRA input tensor hints. Defaults to empty dict.
+        hidden_size (int | None): Hidden size for hidden_states_input. Defaults to None.
+        hidden_dtype (torch.dtype | None): Hidden dtype for hidden_states_input. Defaults to None.
     """
 
     batch_size: DynamicDimensionType = Field(frozen=True, exclude=True)
@@ -49,10 +51,12 @@ class TRTLLMArgumentHint(StrictlyTyped):
     num_tokens: DynamicDimensionType = Field(frozen=True, exclude=True)
     max_blocks_per_seq: DynamicDimensionType = Field(frozen=True, exclude=True)
     beam_width: DynamicDimensionType | int = Field(frozen=True, exclude=True)
+    mapping: TRTLLMMapping = Field(exclude=True)
     num_attn_layers: int | None = Field(default=None, exclude=True, ge=0)
-    tp_size: int = Field(default=1, exclude=True, gt=0)
     gather_context_logits: bool = Field(default=False, exclude=True)
     lora_input_hints: dict[str, TensorTypeHint] = Field(default_factory=dict, exclude=True)
+    hidden_size: int | None = Field(default=None, exclude=True)
+    hidden_dtype: torch.dtype | None = Field(default=None, exclude=True)
     _one: DynamicDimension = PrivateAttr(default=DynamicDimension(name="one", min=1, opt=1, max=1))
 
     @classmethod
@@ -60,15 +64,16 @@ class TRTLLMArgumentHint(StrictlyTyped):
         cls,
         profile_config: TRTLLMOptimizationProfileConfig,
         *,
+        mapping: TRTLLMMapping,
         gather_context_logits: bool,
-        tp_size: int = 1,
     ) -> Self:
         """Configure the argument hint.
 
         Args:
             profile_config (TRTLLMOptimizationProfileConfig): The optimization profile configuration
+            mapping (TRTLLMMapping): The mapping configuration
             gather_context_logits (bool): Whether to gather context logits
-            tp_size (int): The Tensor Parallelism size
+
         Returns:
             Self: The configured argument hint
         """
@@ -112,7 +117,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
             num_tokens=num_tokens,
             max_blocks_per_seq=max_blocks_per_seq,
             beam_width=beam_width,
-            tp_size=tp_size,
+            mapping=mapping,
             gather_context_logits=gather_context_logits,
         )
 
@@ -133,9 +138,31 @@ class TRTLLMArgumentHint(StrictlyTyped):
 
     @computed_field
     @property
-    def input_ids(self) -> TensorTypeHint:
-        """Tensor type hint for input IDs with shape (num_tokens,)."""
-        return TensorTypeHint(shape=(self.num_tokens,), dtype=torch.int32)
+    def input_ids(self) -> TensorTypeHint | None:
+        """Tensor type hint for input IDs with shape (num_tokens,).
+
+        If the pipeline parallelism is used, the input IDs may not be needed.
+        """
+        return (
+            TensorTypeHint(shape=(self.num_tokens,), dtype=torch.int32)
+            if not self.mapping.is_initialized() or self.mapping.is_first_pp_rank()
+            else None
+        )
+
+    @computed_field
+    @property
+    def hidden_states_input(self) -> TensorTypeHint | None:
+        """Tensor type hint for hidden states input with shape (num_tokens, hidden_size).
+
+        It is used for pipeline parallel.
+        """
+        return (
+            TensorTypeHint(shape=(self.num_tokens, self.hidden_size), dtype=self.hidden_dtype)
+            if not (self.mapping.is_initialized() and self.mapping.is_first_pp_rank())
+            and self.hidden_size is not None
+            and self.hidden_dtype is not None
+            else None
+        )
 
     @computed_field
     @property
@@ -147,7 +174,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     @property
     def last_token_ids(self) -> TensorTypeHint | None:
         """Tensor type hint for last token IDs with shape (num_tokens,), None if gather context logits is True."""
-        if self.gather_context_logits:
+        if self.gather_context_logits or (self.mapping.is_initialized() and not self.mapping.is_last_pp_rank()):
             return None
         return TensorTypeHint(shape=(self.batch_size,), dtype=torch.int32)
 
@@ -220,13 +247,14 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_max_attention_window_sizes(self) -> TensorTypeHint:
         """Tensor type hint for host max attention window sizes with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_max_attention_window_sizes"
+        num_attn_layers = len(self.mapping.get_pp_layers(self.num_attn_layers))
         return TensorTypeHint(
             shape=(
                 DynamicDimension(
                     name="host_max_attention_window_sizes",
-                    min=self.num_attn_layers,
-                    opt=self.num_attn_layers,
-                    max=self.num_attn_layers,
+                    min=num_attn_layers,
+                    opt=num_attn_layers,
+                    max=num_attn_layers,
                 ),
             ),
             dtype=torch.int32,
@@ -252,13 +280,14 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_kv_cache_pool_mapping(self) -> TensorTypeHint:
         """Tensor type hint for host KV cache pool mapping with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_kv_cache_pool_mapping"
+        num_attn_layers = len(self.mapping.get_pp_layers(self.num_attn_layers))
         return TensorTypeHint(
             shape=(
                 DynamicDimension(
                     name="host_max_attention_window_sizes",
-                    min=self.num_attn_layers,
-                    opt=self.num_attn_layers,
-                    max=self.num_attn_layers,
+                    min=num_attn_layers,
+                    opt=num_attn_layers,
+                    max=num_attn_layers,
                 ),
             ),
             dtype=torch.int32,
@@ -274,11 +303,11 @@ class TRTLLMArgumentHint(StrictlyTyped):
     @property
     def all_reduce_workspace(self) -> TensorTypeHint | None:
         """Tensor type hint for all reduce workspace with shape (workspace_size,) or None if tp_size is 1."""
-        if self.tp_size == 1:
+        if self.mapping.tp_size == 1:
             return None
         pointers_per_rank = 7
         pointers_of_counter = 2
-        workspace_size = pointers_per_rank * self.tp_size + pointers_of_counter
+        workspace_size = pointers_per_rank * self.mapping.tp_size + pointers_of_counter
         return TensorTypeHint(shape=(workspace_size,), dtype=torch.int64)
 
     @model_serializer(mode="wrap")

--- a/src/ditto/arguments/trtllm_argument_hint.py
+++ b/src/ditto/arguments/trtllm_argument_hint.py
@@ -158,7 +158,8 @@ class TRTLLMArgumentHint(StrictlyTyped):
         """
         return (
             TensorTypeHint(shape=(self.num_tokens, self.hidden_size), dtype=self.hidden_dtype)
-            if not (self.mapping.is_initialized() and self.mapping.is_first_pp_rank())
+            if self.mapping.is_initialized()
+            and not self.mapping.is_first_pp_rank()
             and self.hidden_size is not None
             and self.hidden_dtype is not None
             else None
@@ -247,7 +248,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_max_attention_window_sizes(self) -> TensorTypeHint:
         """Tensor type hint for host max attention window sizes with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_max_attention_window_sizes"
-        num_attn_layers = len(self.mapping.get_pp_layers(self.num_attn_layers))
+        num_attn_layers = self.mapping.get_length_of_pp_layers(self.num_attn_layers)
         return TensorTypeHint(
             shape=(
                 DynamicDimension(
@@ -280,7 +281,7 @@ class TRTLLMArgumentHint(StrictlyTyped):
     def host_kv_cache_pool_mapping(self) -> TensorTypeHint:
         """Tensor type hint for host KV cache pool mapping with shape (num_attn_layers,)."""
         assert self.num_attn_layers is not None, "num_attn_layers needs to be set for host_kv_cache_pool_mapping"
-        num_attn_layers = len(self.mapping.get_pp_layers(self.num_attn_layers))
+        num_attn_layers = self.mapping.get_length_of_pp_layers(self.num_attn_layers)
         return TensorTypeHint(
             shape=(
                 DynamicDimension(

--- a/src/ditto/configs/trtllm/pretrained.py
+++ b/src/ditto/configs/trtllm/pretrained.py
@@ -17,7 +17,7 @@
 from collections.abc import Callable
 from typing import Any
 
-from pydantic import Field, PrivateAttr, computed_field, model_serializer, model_validator
+from pydantic import Field, computed_field, model_serializer, model_validator
 from typing_extensions import Self
 
 from ...literals import DTypeLiteral, QuantAlgoLiteral
@@ -37,7 +37,7 @@ class TRTLLMMapping(StrictlyTyped):
         pp_size (int): Size of pipeline parallel dimension. Defaults to 1.
         moe_tp_size (int): Size of MoE tensor parallel dimension. Defaults to 0.
         moe_ep_size (int): Size of MoE expert parallel dimension. Defaults to 0.
-        rank (int): Current process rank. Defaults to -1.
+        rank (int | None): Current process rank. Defaults to None.
     """
 
     @computed_field
@@ -56,7 +56,7 @@ class TRTLLMMapping(StrictlyTyped):
     pp_size: int = Field(default=1, ge=1)
     moe_tp_size: int = Field(default=0)
     moe_ep_size: int = Field(default=0)
-    _rank: int = PrivateAttr(default=-1)
+    rank: int | None = Field(default=None, exclude=True, validate_default=False)
 
     @property
     def cp_groups(self) -> list[list[int]]:
@@ -143,6 +143,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's checkpoint parallel rank
         """
+        if self.rank is None:
+            return 0
         return self.rank % (self.tp_size * self.cp_size) // self.tp_size
 
     @property
@@ -152,6 +154,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's tensor parallel rank
         """
+        if self.rank is None:
+            return 0
         return self.rank % self.tp_size
 
     @property
@@ -161,6 +165,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's pipeline parallel rank
         """
+        if self.rank is None:
+            return 0
         return self.rank // (self.tp_size * self.cp_size)
 
     @property
@@ -170,6 +176,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's previous pipeline parallel rank
         """
+        if self.rank is None:
+            return 0
         prev_pp_rank = self.rank - self.tp_size * self.cp_size
         if prev_pp_rank < 0:
             prev_pp_rank = prev_pp_rank + self.world_size
@@ -182,6 +190,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's next pipeline parallel rank
         """
+        if self.rank is None:
+            return 0
         next_pp_rank = self.rank + self.tp_size * self.cp_size
         if next_pp_rank >= self.world_size:
             next_pp_rank = next_pp_rank - self.world_size
@@ -194,6 +204,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's MoE tensor parallel rank
         """
+        if self.rank is None:
+            return 0
         return self.tp_rank // self.moe_ep_size
 
     @property
@@ -203,6 +215,8 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             int: Current process's MoE expert parallel rank
         """
+        if self.rank is None:
+            return 0
         return self.tp_rank % self.moe_ep_size
 
     @property
@@ -250,27 +264,6 @@ class TRTLLMMapping(StrictlyTyped):
         """
         return self.moe_ep_groups[self.pp_rank * self.moe_tp_size + self.moe_tp_rank]
 
-    @property
-    def rank(self) -> int:
-        """Get current process's rank.
-
-        Returns:
-            int: Current process's rank
-        """
-        assert self.is_initialized(), "rank can only be accessed after initialization"
-        return self._rank
-
-    @rank.setter
-    def rank(self, rank: int) -> None:
-        """Set current process's rank.
-
-        Args:
-            rank (int): New process rank
-        """
-        assert rank >= 0, f"rank must be non-negative, but got {rank=} < 0"
-        assert rank < self.world_size, f"rank must be lower than world_size, but got {rank=} >= {self.world_size=}"
-        self._rank = rank
-
     @model_validator(mode="before")
     @classmethod
     def resolve_defaults_if_none(cls, data: Any) -> Any:
@@ -316,30 +309,36 @@ class TRTLLMMapping(StrictlyTyped):
         )
         assert not (self.moe_ep_size != 1 and self.cp_size > 1), "CP don't support MoE tp/ep yet"
 
+        if self.rank is not None:
+            assert self.rank >= 0, f"rank must be non-negative, but got {self.rank=} < 0"
+            assert (
+                self.rank < self.world_size
+            ), f"rank must be lower than world_size, but got {self.rank=} >= {self.world_size=}"
+
         return self
-
-    def is_initialized(self) -> bool:
-        """Check if the mapping is initialized.
-
-        Returns:
-            bool: True if the mapping is initialized with rank, False otherwise
-        """
-        return self._rank >= 0
 
     def is_first_pp_rank(self) -> bool:
         """Check if the pp rank of this instance is the first pp rank.
 
+        If the rank is not valid, it assumes to be the first pp rank.
+
         Returns:
             bool: True if the pp rank is 0, False otherwise
         """
+        if self.rank is None:
+            return True
         return self.pp_rank == 0
 
     def is_last_pp_rank(self) -> bool:
         """Check if the pp rank of this instance is the last pp rank.
 
+        If the rank is not valid, it assumes to be the last pp rank.
+
         Returns:
             bool: True if the pp rank is the last pp rank, False otherwise
         """
+        if self.rank is None:
+            return True
         return self.pp_rank == self.pp_size - 1
 
     def get_pp_layers(self, num_decoder_layers: int) -> list[int]:
@@ -351,19 +350,10 @@ class TRTLLMMapping(StrictlyTyped):
         Returns:
             list[int]: List of layers to be parallelized for the current pipeline rank
         """
-        layers_per_pipeline_stage = self.get_length_of_pp_layers(num_decoder_layers)
-        return list(range(self.pp_rank * layers_per_pipeline_stage, (self.pp_rank + 1) * layers_per_pipeline_stage))
-
-    def get_length_of_pp_layers(self, num_decoder_layers: int) -> int:
-        """Get the length of the pipeline layers.
-
-        Args:
-            num_decoder_layers (int): Total number of decoder layers
-
-        Returns:
-            int: Length of the pipeline layers
-        """
-        return num_decoder_layers // self.pp_size
+        num_layers_per_pipeline_stage = num_decoder_layers // self.pp_size
+        return list(
+            range(self.pp_rank * num_layers_per_pipeline_stage, (self.pp_rank + 1) * num_layers_per_pipeline_stage)
+        )
 
 
 class TRTLLMQuantConfig(StrictlyTyped):

--- a/src/ditto/conversion/plugin_converters.py
+++ b/src/ditto/conversion/plugin_converters.py
@@ -25,7 +25,16 @@ from torch_tensorrt.dynamo.conversion._ConverterRegistry import dynamo_tensorrt_
 from torch_tensorrt.dynamo.conversion.converter_utils import get_trt_tensor
 
 from ..debug import enable_plugin_debug_info_hook
-from ..fx.targets import AllGatherPlugin, AllReducePlugin, GemmPlugin, GPTAttentionPlugin, LoraPlugin, Plugin
+from ..fx.targets import (
+    AllGatherPlugin,
+    AllReducePlugin,
+    GemmPlugin,
+    GPTAttentionPlugin,
+    LoraPlugin,
+    Plugin,
+    RecvPlugin,
+    SendPlugin,
+)
 
 
 @dynamo_tensorrt_converter(
@@ -180,6 +189,62 @@ def convert_lora_plugin(
     """
     assert isinstance(target, LoraPlugin)
     return _convert_plugin(ctx, target, args, kwargs, name, plugin_name="lora")
+
+
+@dynamo_tensorrt_converter(
+    RecvPlugin,
+    supports_dynamic_shapes=True,
+)
+@enable_plugin_debug_info_hook
+def convert_recv_plugin(
+    ctx: ConversionContext,
+    target: Target,
+    args: tuple[Argument, ...],
+    kwargs: dict[str, Argument],
+    name: str,
+) -> trt.ITensor | Sequence[trt.ITensor]:
+    """Convert a RecvPlugin target to a TensorRT plugin layer.
+
+    Args:
+        ctx (ConversionContext): The conversion context
+        target (Target): The RecvPlugin target to convert
+        args (tuple[Argument, ...]): Positional arguments to the plugin
+        kwargs (dict[str, Argument]): Keyword arguments to the plugin
+        name (str): Name for the plugin layer
+
+    Returns:
+        trt.ITensor | Sequence[trt.ITensor]: Output tensor(s) from the plugin layer
+    """
+    assert isinstance(target, RecvPlugin)
+    return _convert_plugin(ctx, target, args, kwargs, name, plugin_name="recv")
+
+
+@dynamo_tensorrt_converter(
+    SendPlugin,
+    supports_dynamic_shapes=True,
+)
+@enable_plugin_debug_info_hook
+def convert_send_plugin(
+    ctx: ConversionContext,
+    target: Target,
+    args: tuple[Argument, ...],
+    kwargs: dict[str, Argument],
+    name: str,
+) -> trt.ITensor | Sequence[trt.ITensor]:
+    """Convert a SendPlugin target to a TensorRT plugin layer.
+
+    Args:
+        ctx (ConversionContext): The conversion context
+        target (Target): The SendPlugin target to convert
+        args (tuple[Argument, ...]): Positional arguments to the plugin
+        kwargs (dict[str, Argument]): Keyword arguments to the plugin
+        name (str): Name for the plugin layer
+
+    Returns:
+        trt.ITensor | Sequence[trt.ITensor]: Output tensor(s) from the plugin layer
+    """
+    assert isinstance(target, SendPlugin)
+    return _convert_plugin(ctx, target, args, kwargs, name, plugin_name="send")
 
 
 def _convert_plugin(

--- a/src/ditto/convert.py
+++ b/src/ditto/convert.py
@@ -34,30 +34,28 @@ def convert(
     graph_module: GraphModule,
     argument_hint: TRTLLMArgumentHint,
     trt_config: TensorRTConfig,
-    rank: int,
     *,
     engine_cache: BaseEngineCache | None = None,
     network_name: str | None = None,
-    output_names: list[str] | None = None,
+    debug_node_names: list[str] | None = None,
 ) -> bytes:
     """Convert an graph module to a TensorRT engine."""
+    all_tensor_hints = {name: hint for name, hint in argument_hint.as_dict().items() if hint is not None}
     input_specs = tuple(
-        tensor_type_hint.as_spec(name)
-        for name, tensor_type_hint in argument_hint.as_dict().items()
-        if tensor_type_hint is not None
+        all_tensor_hints[p.name].as_spec(p.name) for p in graph_module.graph.find_nodes(op="placeholder")
     )
     logger.opt(lazy=True).debug("input_specs:\n{x}", x=lambda: "\n".join(str(spec) for spec in input_specs))
 
-    assert len(placeholders := graph_module.graph.find_nodes(op="placeholder")) == len(input_specs)
-    assert all(p.name == i.name for p, i in zip(placeholders, input_specs))
-
+    output_names = ["logits" if argument_hint.mapping.is_last_pp_rank() else "hidden_states_output"]
+    if debug_node_names:
+        output_names.extend(debug_node_names)
     try:
         interpreter = TRTLLMInterpreter(
             graph_module,
             input_specs,
             builder_config=trt_config.builder_config,
             network_flags=trt_config.network_creation_flags,
-            rank=rank,
+            rank=argument_hint.mapping.rank,
             engine_cache=engine_cache,
             network_name=network_name,
             output_names=output_names,
@@ -65,7 +63,7 @@ def convert(
         engine = interpreter.run().serialized_engine
         if should_save_debug_artifacts():
             save_for_debug(
-                f"trt_engine_rank{rank}",
+                f"trt_engine_rank{argument_hint.mapping.rank}",
                 trt.Runtime(TRT_LOGGER).deserialize_cuda_engine(engine),
             )
         return engine

--- a/src/ditto/convert.py
+++ b/src/ditto/convert.py
@@ -40,7 +40,7 @@ def convert(
     debug_node_names: list[str] | None = None,
 ) -> bytes:
     """Convert an graph module to a TensorRT engine."""
-    all_tensor_hints = {name: hint for name, hint in argument_hint.as_dict().items() if hint is not None}
+    all_tensor_hints = argument_hint.as_dict()
     input_specs = tuple(
         all_tensor_hints[p.name].as_spec(p.name) for p in graph_module.graph.find_nodes(op="placeholder")
     )

--- a/src/ditto/debug/engine.py
+++ b/src/ditto/debug/engine.py
@@ -499,7 +499,7 @@ def get_shape_ranges(
                 )
             )
             for name in input_names
-            if name not in ("logits",)
+            if name not in ("logits", "hidden_states_output")
         }
         for profile in optimization_profiles
     ]

--- a/src/ditto/fx/config_gen.py
+++ b/src/ditto/fx/config_gen.py
@@ -258,7 +258,7 @@ def infer_pretrained_config(
         dtype=dtype,
         vocab_size=vocab_size,
         hidden_size=hidden_size,
-        num_hidden_layers=num_hidden_layers,
+        num_hidden_layers=num_hidden_layers * mapping.pp_size,
         num_attention_heads=plugin.num_heads * mapping.tp_size,
         num_key_value_heads=plugin.num_kv_heads * mapping.tp_size,
         intermediate_size=intermediate_size,

--- a/src/ditto/fx/optimize.py
+++ b/src/ditto/fx/optimize.py
@@ -56,6 +56,7 @@ from .passes import (
     ReplaceMMByGemmPlugin,
     ReplaceSDPAByGPTAttentionPlugin,
     ReplaceViewByReshape,
+    ResolveDynamicReshape,
     RewriteFloatingPointLiteralsAsNodes,
     RewriteIndexAsSingleSlice,
     RewritePowAsMul,
@@ -158,6 +159,7 @@ LEVEL2_PASSES: tuple[type[GraphOptimizationPass], ...] = (
     RewritePowAsMul,
     RewriteFloatingPointLiteralsAsNodes,
     RewriteReshapeAsUnsqueeze,
+    ResolveDynamicReshape,
 )
 
 

--- a/src/ditto/fx/passes/__init__.py
+++ b/src/ditto/fx/passes/__init__.py
@@ -50,6 +50,7 @@ from .replace_mm_by_gemm_plugin import ReplaceMMByGemmPlugin
 from .replace_sdpa_by_gpt_attention_plugin import ReplaceSDPAByGPTAttentionPlugin
 from .replace_view_by_reshape import ReplaceViewByReshape
 from .reset_code_gen import ResetCodeGen
+from .resolve_dynamic_reshape import ResolveDynamicReshape
 from .rewrite_fp_literals_as_nodes import RewriteFloatingPointLiteralsAsNodes
 from .rewrite_index_as_single_slice import RewriteIndexAsSingleSlice
 from .rewrite_pow_as_mul import RewritePowAsMul

--- a/src/ditto/fx/passes/__init__.py
+++ b/src/ditto/fx/passes/__init__.py
@@ -43,6 +43,7 @@ from .herd_constants_to_the_right import HerdConstantsToTheRight
 from .index_layers import IndexLayers
 from .insert_gather_last_token_ids import InsertGatherLastTokenIds
 from .parallelize_linear import ParallelizeLinear
+from .parallelize_pipeline import ParallelizePipeline
 from .pop_lora_plugins import PopLoraPlugins
 from .propagate_tensor_parallelism import PropagateTensorParallelism
 from .replace_mm_by_gemm_plugin import ReplaceMMByGemmPlugin

--- a/src/ditto/fx/passes/parallelize_pipeline.py
+++ b/src/ditto/fx/passes/parallelize_pipeline.py
@@ -61,12 +61,8 @@ class ParallelizePipeline(GraphOptimizationPass):
                 not mapping.is_first_pp_rank()
                 and gpt_attn_plugin.layer_idx == layers_to_be_parallelized[0]
                 and (pipeline_input_node := find_input_node_of_pipeline(node))
-                and (input_tensor := get_val(pipeline_input_node, FakeTensor)) is not None
                 and (input_ids_node := find_input_ids_node(graph))
             ):
-                self.argument_hint.hidden_size = input_tensor.shape[-1]
-                self.argument_hint.hidden_dtype = input_tensor.dtype
-
                 with graph.inserting_after(input_ids_node):
                     hidden_states_input = Placeholder.create(
                         graph, "hidden_states_input", self.argument_hint.hidden_states_input

--- a/src/ditto/fx/passes/parallelize_pipeline.py
+++ b/src/ditto/fx/passes/parallelize_pipeline.py
@@ -1,0 +1,247 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import tensorrt as trt
+import torch
+from torch._subclasses import FakeTensor
+from torch.fx import Graph, GraphModule, Node
+
+from ...arguments import TRTLLMArgumentHint
+from ...types import DataType
+from ..nodes import AddTensorTensor, Placeholder
+from ..targets import GPTAttentionPlugin, RecvPlugin, SendPlugin
+from ..utils import get_val
+from .infra import (
+    GraphOptimizationPass,
+    PassResult,
+    cleanup,
+    propagate_metadata_from,
+)
+
+
+class ParallelizePipeline(GraphOptimizationPass):
+    """Parallelize the pipeline in the graph (Pipeline Parallelism).
+
+    Attributes:
+        argument_hint (TRTLLMArgumentHint): The argument hint of the model
+    """
+
+    argument_hint: TRTLLMArgumentHint
+
+    def call(self, graph_module: GraphModule) -> PassResult:
+        overall_modified = False
+        graph = graph_module.graph
+        mapping = self.argument_hint.mapping
+        assert (
+            num_attn_layers := get_num_gpt_attn_plugin_nodes(graph)
+        ) % mapping.pp_size == 0, (
+            f"Number of attention layers ({num_attn_layers}) must be divisible by pipeline stages ({mapping.pp_size})"
+        )
+        layers_to_be_parallelized = mapping.get_pp_layers(num_attn_layers)
+        for node in graph.nodes:
+            if not (
+                isinstance(gpt_attn_plugin := node.target, GPTAttentionPlugin)
+                and gpt_attn_plugin.layer_idx in layers_to_be_parallelized
+            ):
+                continue
+
+            if (
+                not mapping.is_first_pp_rank()
+                and gpt_attn_plugin.layer_idx == layers_to_be_parallelized[0]
+                and (pipeline_input_node := find_input_node_of_pipeline(node))
+                and (input_tensor := get_val(pipeline_input_node, FakeTensor)) is not None
+                and (input_ids_node := find_input_ids_node(graph))
+            ):
+                self.argument_hint.hidden_size = input_tensor.shape[-1]
+                self.argument_hint.hidden_dtype = input_tensor.dtype
+
+                with graph.inserting_after(input_ids_node):
+                    hidden_states_input = Placeholder.create(
+                        graph, "hidden_states_input", self.argument_hint.hidden_states_input
+                    )
+                input_ids_node.replace_all_uses_with(hidden_states_input)
+
+                recv_node = insert_recv_plugin(graph, hidden_states_input.node, mapping.prev_pp_rank)
+                pipeline_input_node.replace_all_uses_with(recv_node)
+            elif (
+                not mapping.is_last_pp_rank()
+                and gpt_attn_plugin.layer_idx == layers_to_be_parallelized[-1]
+                and (next_gpt_attn_plugin_node := find_next_gpt_attn_plugin_node(node))
+                and (pipeline_output_node := find_input_node_of_pipeline(next_gpt_attn_plugin_node))
+                and (graph_output_node := find_output_node(graph))
+            ):
+                send_node = insert_send_plugin(graph, pipeline_output_node, mapping.next_pp_rank)
+                graph_output_node.replace_all_uses_with(send_node)
+
+            gpt_attn_plugin.layer_idx = gpt_attn_plugin.layer_idx - layers_to_be_parallelized[0]
+            gpt_attn_plugin.layer_idx_in_cache_pool = gpt_attn_plugin.layer_idx
+            overall_modified = True
+
+        if overall_modified:
+            cleanup(graph_module)
+            unused_placeholders = [node for node in graph.find_nodes(op="placeholder") if len(node.users) == 0]
+            for placeholder in unused_placeholders:
+                graph.erase_node(placeholder)
+
+        return PassResult(graph_module=graph_module, modified=False)
+
+
+def get_num_gpt_attn_plugin_nodes(graph: Graph) -> int:
+    """Get the number of GPTAttentionPlugin nodes in the graph.
+
+    Args:
+        graph (Graph): The graph to get the number of GPTAttentionPlugin layers from
+
+    Returns:
+        int: The number of GPTAttentionPlugin layers in the graph
+    """
+    return sum(1 for node in graph.nodes if isinstance(node.target, GPTAttentionPlugin))
+
+
+def find_next_gpt_attn_plugin_node(node: Node) -> Node | None:
+    """Find the next GPTAttentionPlugin node in the graph.
+
+    Args:
+        node (Node): The node to find the next GPTAttentionPlugin node from
+
+    Returns:
+        Node | None: The next GPTAttentionPlugin node in the graph or None if no such node is found
+    """
+    visited: set[Node] = set()
+    q: list[Node] = list(node.users)
+    while q:
+        current = q.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        if isinstance(current.target, GPTAttentionPlugin):
+            return current
+        if current.users:
+            q.extend(current.users)
+
+    return None
+
+
+def find_input_ids_node(graph: Graph) -> Node:
+    """Find the logits node in the graph.
+
+    Args:
+        graph (Graph): The graph to find the logits node from
+
+    Returns:
+        Node: The logits node in the graph
+    """
+    for input_node in graph.find_nodes(op="placeholder"):
+        if input_node.name == "input_ids":
+            return input_node
+    raise RuntimeError("No input_ids placeholder found in the graph")
+
+
+def find_input_node_of_pipeline(node: Node) -> Node | None:
+    """Find the input node of the pipeline.
+
+    Args:
+        node (Node): The node to find the input node from
+
+    Returns:
+        Node | None: The input node in the pipeline or None if no such node is found
+    """
+
+    def find_nearest_add_node() -> Node | None:
+        """Find the nearest succeeding add node in the graph.
+
+        Returns:
+            Node | None: The nearest add node in the graph or None if no such node is found
+        """
+        visited: set[Node] = set()
+        queue: list[Node] = [node]
+        while queue:
+            current = queue.pop(0)
+            if current in visited:
+                continue
+            visited.add(current)
+            if _ := AddTensorTensor.specialize_from(current):
+                return current
+            if current.users:
+                queue.extend(current.users)
+
+        return None
+
+    if not (expected_output_node := find_nearest_add_node()):
+        return None
+    visited: set[Node] = set()
+    queue: list[Node] = [node]
+    while queue:
+        current = queue.pop(0)
+        if current in visited:
+            continue
+        visited.add(current)
+        if len(current.users) == 2 and expected_output_node in current.users:
+            return current
+        for input_node in current.all_input_nodes:
+            queue.append(input_node)
+
+    return None
+
+
+def insert_send_plugin(graph: Graph, to: Node, tgt_rank: int) -> Node:
+    """Insert a send plugin node into the graph.
+
+    Args:
+        graph (Graph): The graph to insert the send plugin node into
+        to (Node): The node to insert the send plugin node after
+        tgt_rank (int): The rank that receives the tensor
+
+    Returns:
+        Node: The send plugin node
+    """
+    assert (to_val := get_val(to, torch.Tensor)) is not None, f"Failed to get tensor value from {to.format_node()}"
+    send_plugin = SendPlugin(tgt_rank=tgt_rank, type_id=DataType(dtype=to_val.dtype).to(trt.DataType))
+    with graph.inserting_after(to):
+        send = graph.call_function(send_plugin, (to,))
+        propagate_metadata_from(to, to=send)
+    return send
+
+
+def insert_recv_plugin(graph: Graph, to: Node, src_rank: int) -> Node:
+    """Insert a recv plugin node into the graph.
+
+    Args:
+        graph (Graph): The graph to insert the recv plugin node into
+        to (Node): The node to insert the recv plugin node after
+        src_rank (int): The rank that sends the tensor
+
+    Returns:
+        Node: The recv plugin node
+    """
+    assert (to_val := get_val(to, torch.Tensor)) is not None, f"Failed to get tensor value from {to.format_node()}"
+    recv_plugin = RecvPlugin(src_rank=src_rank, type_id=DataType(dtype=to_val.dtype).to(trt.DataType))
+    with graph.inserting_after(to):
+        recv = graph.call_function(recv_plugin, (to,))
+        propagate_metadata_from(to, to=recv)
+    return recv
+
+
+def find_output_node(graph: Graph) -> Node:
+    """Find the output node in the graph.
+
+    Args:
+        graph (Graph): The graph to find the output node from
+
+    Returns:
+        Node: The output node in the graph
+    """
+    output_node = graph.find_nodes(op="output")[0]
+    assert isinstance(input_args := output_node.args[0], tuple)
+    return input_args[0]

--- a/src/ditto/fx/passes/parallelize_pipeline.py
+++ b/src/ditto/fx/passes/parallelize_pipeline.py
@@ -18,6 +18,7 @@ from torch._subclasses import FakeTensor
 from torch.fx import Graph, GraphModule, Node
 
 from ...arguments import TRTLLMArgumentHint
+from ...constants import INPUT_IDS
 from ...types import DataType
 from ..nodes import AddTensorTensor, BinaryElementwise, Placeholder, SymSizeInt, Unsqueeze
 from ..targets import GPTAttentionPlugin, RecvPlugin, SendPlugin
@@ -152,7 +153,7 @@ def find_input_ids_node(graph: Graph) -> Node:
         Node: The logits node in the graph
     """
     for input_node in graph.find_nodes(op="placeholder"):
-        if input_node.name == "input_ids":
+        if input_node.name == INPUT_IDS:
             return input_node
     raise RuntimeError("No input_ids placeholder found in the graph")
 

--- a/src/ditto/fx/passes/resolve_dynamic_reshape.py
+++ b/src/ditto/fx/passes/resolve_dynamic_reshape.py
@@ -1,0 +1,41 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from torch.fx import Node
+
+from ..nodes import Reshape, SymSizeInt
+from .infra import ModifiedInsideThePass, NodewiseOptimizationPass, NodewisePassResult
+
+
+class ResolveDynamicReshape(NodewiseOptimizationPass):
+    """Resolve reshape operations containing a single dynamic(symbolic) dimension.
+
+    It replaces the dynamic dimension with the automatic inference value (-1) when the target reshape operation
+    has a single symbolic dimension.
+
+    Example:
+        Before: reshape(x, [dim0, dynamic_dim, dim2])
+        After: reshape(x, [dim0, -1, dim2])
+    """
+
+    def rewrite(self, node: Node) -> dict[Node, NodewisePassResult]:
+        if (reshape := Reshape.specialize_from(node)) and (
+            len([dim for dim in reshape.shape if isinstance(dim, Node) and SymSizeInt.specialize_from(dim)]) == 1
+        ):
+            new_shape = [dim if isinstance(dim, int) else -1 for dim in reshape.shape]
+            args, kwargs = reshape.args_kwargs(shape=new_shape)
+            reshape.node.args = args
+            reshape.node.kwargs = kwargs
+            return {node: ModifiedInsideThePass()}
+        return {}

--- a/src/ditto/fx/passes/resolve_dynamic_reshape.py
+++ b/src/ditto/fx/passes/resolve_dynamic_reshape.py
@@ -31,7 +31,14 @@ class ResolveDynamicReshape(NodewiseOptimizationPass):
 
     def rewrite(self, node: Node) -> dict[Node, NodewisePassResult]:
         if (reshape := Reshape.specialize_from(node)) and (
-            len([dim for dim in reshape.shape if isinstance(dim, Node) and SymSizeInt.specialize_from(dim)]) == 1
+            len(
+                [
+                    dim
+                    for dim in reshape.shape
+                    if dim == -1 or (isinstance(dim, Node) and SymSizeInt.specialize_from(dim))
+                ]
+            )
+            == 1
         ):
             new_shape = [dim if isinstance(dim, int) else -1 for dim in reshape.shape]
             args, kwargs = reshape.args_kwargs(shape=new_shape)

--- a/src/ditto/fx/passes/resolve_dynamic_reshape.py
+++ b/src/ditto/fx/passes/resolve_dynamic_reshape.py
@@ -30,15 +30,10 @@ class ResolveDynamicReshape(NodewiseOptimizationPass):
     """
 
     def rewrite(self, node: Node) -> dict[Node, NodewisePassResult]:
-        if (reshape := Reshape.specialize_from(node)) and (
-            len(
-                [
-                    dim
-                    for dim in reshape.shape
-                    if dim == -1 or (isinstance(dim, Node) and SymSizeInt.specialize_from(dim))
-                ]
-            )
-            == 1
+        if (
+            (reshape := Reshape.specialize_from(node))
+            and -1 not in reshape.shape
+            and (len([dim for dim in reshape.shape if isinstance(dim, Node) and SymSizeInt.specialize_from(dim)]) == 1)
         ):
             new_shape = [dim if isinstance(dim, int) else -1 for dim in reshape.shape]
             args, kwargs = reshape.args_kwargs(shape=new_shape)

--- a/src/ditto/fx/targets/__init__.py
+++ b/src/ditto/fx/targets/__init__.py
@@ -30,4 +30,6 @@ from .lora_plugin import (
     LoraProto,
 )
 from .plugin import Plugin
+from .recv_plugin import RecvPlugin
 from .rope import FAKE_ROPE_TARGETS
+from .send_plugin import SendPlugin

--- a/src/ditto/fx/targets/recv_plugin.py
+++ b/src/ditto/fx/targets/recv_plugin.py
@@ -1,0 +1,43 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import tensorrt as trt
+import torch
+
+from .fake_tensor_mode import is_in_fake_tensor_mode
+from .plugin import Plugin
+
+
+class RecvPlugin(Plugin):
+    """TensorRT plugin implementation of Recv.
+
+    Attributes:
+        src_rank (int): The rank that sends the tensor to
+        type_id (trt.DataType): The data type of the tensor to gather
+    """
+
+    # the order of the attributes does matter!
+    src_rank: int
+    type_id: trt.DataType
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if is_in_fake_tensor_mode():
+            return x
+        raise NotImplementedError(f"{type(self).__name__} doesn't have implementation")

--- a/src/ditto/fx/targets/send_plugin.py
+++ b/src/ditto/fx/targets/send_plugin.py
@@ -1,0 +1,43 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from typing import Any
+
+import tensorrt as trt
+import torch
+
+from .fake_tensor_mode import is_in_fake_tensor_mode
+from .plugin import Plugin
+
+
+class SendPlugin(Plugin):
+    """TensorRT plugin implementation of Send.
+
+    Attributes:
+        tgt_rank (int): The rank that receives the tensor
+        type_id (trt.DataType): The data type of the tensor to gather
+    """
+
+    # the order of the attributes does matter!
+    tgt_rank: int
+    type_id: trt.DataType
+
+    def __call__(
+        self,
+        x: torch.Tensor,
+        **kwargs: Any,
+    ) -> torch.Tensor:
+        if is_in_fake_tensor_mode():
+            return x
+        raise NotImplementedError(f"{type(self).__name__} doesn't have implementation")

--- a/src/ditto/literals.py
+++ b/src/ditto/literals.py
@@ -96,6 +96,7 @@ PassName = Literal[
     "ReplaceSDPAByGPTAttentionPlugin",
     "ReplaceViewByReshape",
     "ResetCodeGen",
+    "ResolveDynamicReshape",
     "RewriteFloatingPointLiteralsAsNodes",
     "RewriteReshapeAsUnsqueeze",
     "RewriteSplitAsSlices",

--- a/src/ditto/literals.py
+++ b/src/ditto/literals.py
@@ -89,6 +89,7 @@ PassName = Literal[
     "IndexLayers",
     "InsertGatherLastTokenIds",
     "ParallelizeLinear",
+    "ParallelizePipeline",
     "PopLoraPlugins",
     "PropagateTensorParallelism",
     "ReplaceMMByGemmPlugin",

--- a/src/ditto/transform.py
+++ b/src/ditto/transform.py
@@ -86,7 +86,7 @@ def transform(
     logger.debug("Running post-inlining passes")
     with fake_tensor_prop_on_node_creation(graph_module), ignore_symbolic_shapes_warning():
         graph_module = post_inline_pass_manager(graph_module)
-    update_argument_hint(argument_hint, graph_module)
+    update_argument_hint(argument_hint, graph_module, dtype)
 
     save_for_debug("initial_graph_module", graph_module)
 

--- a/src/ditto/transform.py
+++ b/src/ditto/transform.py
@@ -24,7 +24,7 @@ from torch_tensorrt.dynamo.lowering.passes import (
 )
 
 from .arguments import TRTLLMArgumentHint
-from .configs import TRTLLMMapping, TRTLLMModelConfig
+from .configs import TRTLLMModelConfig
 from .contexts import ignore_symbolic_shapes_warning
 from .debug import save_for_debug
 from .fx import (
@@ -111,35 +111,36 @@ def transform(
 def parallelize(
     graph_module: GraphModule,
     argument_hint: TRTLLMArgumentHint,
-    mapping: TRTLLMMapping,
 ) -> Generator[tuple[int, GraphModule], None, None]:
     """Parallelize the graph module.
+
+    This function is used to parallelize the graph module for each rank, and update the mapping's rank in the argument
+    hint.
 
     Args:
         graph_module (GraphModule): The input graph module to parallelize
         argument_hint (TRTLLMArgumentHint): The argument hint of the parallelized graph module
-        mapping (TRTLLMMapping): The mapping of the parallelized graph module
 
     Returns:
         Generator[tuple[int, GraphModule], None, None]:
             A generator that yields the parallelized graph module for each rank
     """
-    if mapping.world_size == 1:
-        argument_hint.mapping = mapping.copy_with_rank(0)
+    if argument_hint.mapping.world_size == 1:
+        argument_hint.mapping.rank = 0
         yield 0, graph_module
         return
 
     logger.info("Parallelizing the graph module")
     save_for_debug("graph_module_before_parallelization", graph_module)
-    for rank in range(mapping.world_size):
+    for rank in range(argument_hint.mapping.world_size):
         logger.debug(f"Running parallelize passes for rank {rank}")
         copied_graph_module = copy_graph_module(graph_module)
-        argument_hint.mapping = mapping.copy_with_rank(rank)
+        argument_hint.mapping.rank = rank
         parallelize_pass_manager = DynamoPassManager()
-        if mapping.tp_size > 1:
+        if argument_hint.mapping.tp_size > 1:
             parallelize_pass_manager.add_pass(PropagateTensorParallelism(mapping=argument_hint.mapping).as_transform())
             parallelize_pass_manager.add_pass(ParallelizeLinear(mapping=argument_hint.mapping).as_transform())
-        if mapping.pp_size > 1:
+        if argument_hint.mapping.pp_size > 1:
             parallelize_pass_manager.add_pass(ParallelizePipeline(argument_hint=argument_hint).as_transform())
         with fake_tensor_prop_on_node_creation(copied_graph_module), ignore_symbolic_shapes_warning():
             yield rank, parallelize_pass_manager(copied_graph_module)


### PR DESCRIPTION
## Summary
- Added `RecvPlugin` and `SendPlugin`.
- Updated `TRTLLMMapping` to support pipeline parallelism.
- Updated `TRTLLMArgumentHint` to support input variants based on rank when pipeline parallelism is applied.
- Added `ParallelizePipeline` and `ResolveDynamicReshape` passes.
  - The `ParallelizePipeline` pass constructs a graph for each rank's pipeline based on the GPT attention plugins and their residual paths.
  - The `ResolveDynamicReshape` pass resolves reshape layers containing a single dynamic(symbolic) dimension. It replaces the dynamic dimension with the automatic inference value (-1).
- minor update and fix:
  - Some classes and functions that previously received `tp_size` now take a `TRTLLMMapping` instance.
  - The output node names are determined at the time of `convert`.

## Note
- Models where the number of decoder layers is not divided by pipeline parallelism size are not supported.
- TensorRT-LLM doesn't support the following models with pipeline parallelism. But, ditto can support them.
  - `google/gemma-2-9b-it`
  - `microsoft/phi-4`
  - `CohereForAI/aya-expanse-8b`