### PR TITLE
Support non-default scale with SDPA

### DIFF
--- a/src/ditto/fx/nodes/scaled_dot_product_attention.py
+++ b/src/ditto/fx/nodes/scaled_dot_product_attention.py
@@ -35,23 +35,22 @@ class ScaledDotProductAttention(FinalCallFunction):
         query (Node): The query tensor node in the attention computation.
         key (Node): The key tensor node in the attention computation.
         value (Node): The value tensor node in the attention computation.
+        scale (float): An optional scaling factor for the dot-product attention.
         attn_mask (Node | None): The attention mask node, if any. Defaults to None.
         dropout_p (float): The dropout probability applied during attention computation.
             Defaults to 0.0.
         is_causal (bool): Whether the attention is causal (e.g., masking future tokens).
             Defaults to False.
-        scale (float | None): An optional scaling factor for the dot-product attention.
-            Defaults to None.
         enable_gqa (bool): Whether to enable grouped-query attention (GQA). Defaults to False.
     """
 
     query: Node
     key: Node
     value: Node
+    scale: float
     attn_mask: Node | None = None
     dropout_p: float = 0.0
     is_causal: bool = False
-    scale: float
     enable_gqa: bool = False
 
     @classmethod
@@ -82,8 +81,6 @@ class ScaledDotProductAttention(FinalCallFunction):
                 continue
             if (value := getattr(self, name)) != (default_value := field.get_default()):
                 if is_mla_enabled:
-                    continue
-                if name == "scale" and self.default_scale and math.isclose(value, self.default_scale):
                     continue
                 logger.warning(
                     f"Cannot support the non-default '{name}={value}' provided to `F.scaled_dot_product_attention` "

--- a/src/ditto/fx/optimize.py
+++ b/src/ditto/fx/optimize.py
@@ -55,6 +55,7 @@ from .passes import (
     HerdConstantsToTheRight,
     IndexLayers,
     InsertGatherLastTokenIds,
+    OverrideMulScalarTypePromotion,
     ParallelizeLinear,
     PopLoraPlugins,
     PropagateTensorParallelism,
@@ -251,6 +252,7 @@ def get_trtllm_conversion_transform(
     """
     passes: list[type[GraphOptimizationPass] | GraphOptimizationPass] = [
         *get_trtllm_output_adaptation_passes(model_config.gather_context_logits),
+        OverrideMulScalarTypePromotion,
         CastRouterToFP32,
         ReplaceMoEByMoEPlugin(dtype=dtype),
         FuseQKVProjections,

--- a/src/ditto/fx/passes/__init__.py
+++ b/src/ditto/fx/passes/__init__.py
@@ -44,6 +44,7 @@ from .fuse_reciprocal_mul import FuseReciprocalMul
 from .herd_constants_to_the_right import HerdConstantsToTheRight
 from .index_layers import IndexLayers
 from .insert_gather_last_token_ids import InsertGatherLastTokenIds
+from .override_mul_scalar_type_promotion import OverrideMulScalarTypePromotion
 from .parallelize_linear import ParallelizeLinear
 from .parallelize_pipeline import ParallelizePipeline
 from .pop_lora_plugins import PopLoraPlugins

--- a/src/ditto/fx/passes/override_mul_scalar_type_promotion.py
+++ b/src/ditto/fx/passes/override_mul_scalar_type_promotion.py
@@ -1,0 +1,45 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from torch.fx import Node
+
+from ..nodes import GetAttr, MulTensorScalar
+from ..utils import get_val
+from .infra import ModifiedInsideThePass, NodewiseOptimizationPass, NodewisePassResult
+
+
+class OverrideMulScalarTypePromotion(NodewiseOptimizationPass):
+    """Cast the scalar (second input node) of a mul node to the dtype of the fisrt input node.
+
+    This pass is to suppress the type promotion of float16/bfloat16 tensors to float32 by torch-tensorrt converter.
+    """
+
+    def rewrite(self, node: Node) -> dict[Node, NodewisePassResult]:
+        if not (
+            (mul := MulTensorScalar.specialize_from(node))
+            and isinstance((input_val := get_val(mul.this)), torch.Tensor)
+            and (input_val.dtype in (torch.float16, torch.bfloat16))
+            and isinstance(mul.other, float)
+        ):
+            return {}
+
+        graph = node.graph
+        with graph.inserting_before(node):
+            rhs_cast = GetAttr.create(graph, f"{mul.name}_rhs_cast", torch.tensor(mul.other, dtype=input_val.dtype))
+            args, kwargs = mul.args_kwargs(other=rhs_cast.node)
+            mul.node.args = args
+            mul.node.kwargs = kwargs
+
+        return {node: ModifiedInsideThePass()}

--- a/src/ditto/literals.py
+++ b/src/ditto/literals.py
@@ -92,6 +92,7 @@ PassName = Literal[
     "HerdConstantsToTheRight",
     "IndexLayers",
     "InsertGatherLastTokenIds",
+    "OverrideMulScalarTypePromotion",
     "ParallelizeLinear",
     "ParallelizePipeline",
     "PopLoraPlugins",


### PR DESCRIPTION
# Summary

- Support non-default scale with SDPA.
- Support the multiplication between non-float32 and float32 tensors by downcasting float32 to a lower precision type instead of type promotion.
  - Add `CastMulScalarToInputDtype` pass

# Test models

- [ibm-granite/granite-3.2-2b-instruct](https://huggingface.co/ibm-granite/granite-3.2-2b-instruct/tree/main)