### PR TITLE
Support WoQ (W8A16, W4A16) for CompressedTensors

### DIFF
--- a/docs/GUIDE.md
+++ b/docs/GUIDE.md
@@ -19,7 +19,7 @@ cd Torch-TRTLLM
 ```
 Then, run the following command to create an environment with dependencies installed.
 ```
-conda create -f conda/environment.yml
+conda env create --file conda/environment.yml
 ```
 Finally, install Ditto.
 ```
@@ -135,58 +135,57 @@ We do not support building a tensor-parallelized LoRA-enabled engine yet, but we
 
 #### Full Usage
 ```
- Usage: ditto build [OPTIONS] MODEL_ID                                                                                                                                     
-                                                                                                                                                                           
- Build a TensorRT-LLM engine from a pretrained model.                                                                                                                      
-                                                                                                                                                                           
-╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ *    model_id      TEXT  A pretrained model name or path. [default: None] [required]                                                                                    │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
-╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
-│ --add-output                                                                 TEXT                             List of node names to add as output. See docs/DEBUG.md    │
-│                                                                                                               for details.                                              │
-│                                                                                                               [default: <class 'list'>]                                 │
-│ --peft-ids                        -p                                         TEXT                             List of LoRA adapter IDs to apply to the model.           │
-│                                                                                                               [default: <class 'list'>]                                 │
-│ --output-dir                      -o                                         TEXT                             Path to the output directory. If not specified,           │
-│                                                                                                               `./engines/<model_id>` will be used.                      │
-│ --dtype                                                                      [auto|float32|float16|bfloat16]  Data type to use for the model. Defaults to `auto`.       │
-│                                                                                                               [default: auto]                                           │
-│ --verbose-failure                     --no-verbose-failure                                                    Show local variable values on failure.                    │
-│                                                                                                               [default: no-verbose-failure]                             │
-│ --trust-remote-code                   --no-trust-remote-code                                                  Trust remote code from Hugging Face Hub.                  │
-│                                                                                                               [default: no-trust-remote-code]                           │
-│ --run-matmuls-in-fp32                 --no-run-matmuls-in-fp32                                                Run matmuls in fp32. [default: no-run-matmuls-in-fp32]    │
-│ --run-activations-in-model-dtype      --no-run-activations-in-model-dtype                                     Run activations in model dtype.                           │
-│                                                                                                               [default: run-activations-in-model-dtype]                 │
-│ --max-batch-size                                                             INTEGER                          Maximum number of requests that the engine can schedule.  │
-│                                                                                                               [default: 2048]                                           │
-│ --max-seq-len                                                                INTEGER                          Maximum total length of one request, including prompt and │
-│                                                                                                               generated output.                                         │
-│                                                                                                               [default: None]                                           │
-│ --max-num-tokens                                                             INTEGER                          Maximum number of batched input tokens after padding is   │
-│                                                                                                               removed in each batch.                                    │
-│                                                                                                               [default: 8192]                                           │
-│ --opt-num-tokens                                                             INTEGER                          Optimal number of batched input tokens after padding is   │
-│                                                                                                               removed in each batch.                                    │
-│                                                                                                               [default: None]                                           │
-│ --max-beam-width                                                             INTEGER                          Maximum number of beams for beam search decoding.         │
-│                                                                                                               [default: 1]                                              │
-│ --tp-size                                                                    INTEGER RANGE [x>=1]             N-way tensor parallelism size. [default: 1]               │
-│ --logits-dtype                                                               [float32|float16|bfloat16]       Data type of logits. Defaults to `float32`.               │
-│                                                                                                               [default: float32]                                        │
-│ --gather-context-logits               --no-gather-context-logits                                              Enable gathering context logits.                          │
-│                                                                                                               [default: no-gather-context-logits]                       │
-│ --gather-generation-logits            --no-gather-generation-logits                                           Enable gathering generation logits.                       │
-│                                                                                                               [default: no-gather-generation-logits]                    │
-│ --gather-all-logits                   --no-gather-all-logits                                                  Equivalent to `--gather-context-logits                    │
-│                                                                                                               --gather-generation-logits`.                              │
-│                                                                                                               [default: no-gather-all-logits]                           │
-│ --run-routers-in-model-dtype          --no-run-routers-in-model-dtype                                         Run linear layers for routers in MoE models in model      │
-│                                                                                                               dtype instead of FP32.                                    |
-│                                                                                                               [default: no-run-routers-in-model-dtype]                  │
-│ --help                            -h                                                                          Show this message and exit.                               │
-╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+ Usage: ditto build [OPTIONS] MODEL_ID
+
+ Build a TensorRT-LLM engine from a pretrained model.
+
+╭─ Arguments ─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ *    model_id      TEXT  A pretrained model name or path. [default: None] [required]                                                                                            │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
+╭─ Options ───────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╮
+│ --add-output                                                                 TEXT                             List of node names to add as output. See docs/DEBUG.md for        │
+│                                                                                                               details.                                                          │
+│                                                                                                               [default: <class 'list'>]                                         │
+│ --peft-ids                        -p                                         TEXT                             List of LoRA adapter IDs to apply to the model.                   │
+│                                                                                                               [default: <class 'list'>]                                         │
+│ --output-dir                      -o                                         TEXT                             Path to the output directory. If not specified,                   │
+│                                                                                                               `./engines/<model_id>` will be used.                              │
+│ --dtype                                                                      [auto|float32|float16|bfloat16]  Data type to use for the model. Defaults to `auto`.               │
+│                                                                                                               [default: auto]                                                   │
+│ --verbose-failure                     --no-verbose-failure                                                    Show local variable values on failure.                            │
+│                                                                                                               [default: no-verbose-failure]                                     │
+│ --trust-remote-code                   --no-trust-remote-code                                                  Trust remote code from Hugging Face Hub.                          │
+│                                                                                                               [default: no-trust-remote-code]                                   │
+│ --run-matmuls-in-fp32                 --no-run-matmuls-in-fp32                                                Run matmuls in fp32. [default: no-run-matmuls-in-fp32]            │
+│ --run-activations-in-model-dtype      --no-run-activations-in-model-dtype                                     Run activations in model dtype.                                   │
+│                                                                                                               [default: run-activations-in-model-dtype]                         │
+│ --max-batch-size                                                             INTEGER                          Maximum number of requests that the engine can schedule.          │
+│                                                                                                               [default: 2048]                                                   │
+│ --max-seq-len                                                                INTEGER                          Maximum total length of one request, including prompt and         │
+│                                                                                                               generated output.                                                 │
+│                                                                                                               [default: None]                                                   │
+│ --max-num-tokens                                                             INTEGER                          Maximum number of batched input tokens after padding is removed   │
+│                                                                                                               in each batch.                                                    │
+│                                                                                                               [default: 8192]                                                   │
+│ --opt-num-tokens                                                             INTEGER                          Optimal number of batched input tokens after padding is removed   │
+│                                                                                                               in each batch.                                                    │
+│                                                                                                               [default: None]                                                   │
+│ --max-beam-width                                                             INTEGER                          Maximum number of beams for beam search decoding. [default: 1]    │
+│ --pp-size                                                                    INTEGER RANGE [x>=1]             N-way pipeline parallelism size. [default: 1]                     │
+│ --tp-size                                                                    INTEGER RANGE [x>=1]             N-way tensor parallelism size. [default: 1]                       │
+│ --logits-dtype                                                               [float32|float16|bfloat16]       Data type of logits. Defaults to `float32`. [default: float32]    │
+│ --gather-context-logits               --no-gather-context-logits                                              Enable gathering context logits.                                  │
+│                                                                                                               [default: no-gather-context-logits]                               │
+│ --gather-generation-logits            --no-gather-generation-logits                                           Enable gathering generation logits.                               │
+│                                                                                                               [default: no-gather-generation-logits]                            │
+│ --gather-all-logits                   --no-gather-all-logits                                                  Equivalent to `--gather-context-logits                            │
+│                                                                                                               --gather-generation-logits`.                                      │
+│                                                                                                               [default: no-gather-all-logits]                                   │
+│ --run-routers-in-model-dtype          --no-run-routers-in-model-dtype                                         Run linear layers for routers in MoE models in model dtype        │
+│                                                                                                               instead of FP32.                                                  │
+│                                                                                                               [default: no-run-routers-in-model-dtype]                          │
+│ --help                            -h                                                                          Show this message and exit.                                       │
+╰─────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────────╯
 ```
 
 

--- a/src/ditto/fx/passes/fuse_dequantizes.py
+++ b/src/ditto/fx/passes/fuse_dequantizes.py
@@ -94,7 +94,6 @@ def are_fusible(dequantizes: list[Dequantize]) -> bool:
         all(dequantizes[0].target.bits == dequantize.target.bits for dequantize in dequantizes[1:])
         and all(dequantizes[0].target.mode == dequantize.target.mode for dequantize in dequantizes[1:])
         and dequantizes[0].target.mode in (QuantizeMode.PER_TENSOR, QuantizeMode.PER_GROUP, QuantizeMode.PER_CHANNEL)
-        and all(dequantizes[0].target.algorithm == dequantize.target.algorithm for dequantize in dequantizes[1:])
         and (qweight_nodes := [dequantize.qweight for dequantize in dequantizes])
         and (scale_nodes := [dequantize.scale for dequantize in dequantizes])
     ):

--- a/src/ditto/fx/passes/replace_mm_by_fp8_gemm_plugin.py
+++ b/src/ditto/fx/passes/replace_mm_by_fp8_gemm_plugin.py
@@ -36,12 +36,13 @@ class ReplaceMMByFp8GemmPlugin(NodewiseOptimizationPass):
             and (other := get_tensor_metadata(linear.mm.other))
             and len(other.shape) == 2
             and (activation_quantization := linear.activation_quantization) is not None
-            and (activation_quantization.scale is not None)
+            and activation_quantization.quant_mode == QuantizeMode.PER_TENSOR
+            and activation_quantization.scale is not None
             and (dequantize := Dequantize.specialize_from(linear.mm.other)) is not None
             and dequantize.qweight_tensor is not None
             and dequantize.qweight_tensor.dtype == torch.float8_e4m3fn
             and dequantize.scale_tensor is not None
-            and dequantize.target.mode in (QuantizeMode.PER_TENSOR, QuantizeMode.PER_CHANNEL)
+            and dequantize.target.mode == QuantizeMode.PER_TENSOR
             and (graph_module := node.graph.owning_module) is not None
         ):
             return {}

--- a/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
+++ b/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
@@ -24,6 +24,7 @@ from ...types import DataType
 from ..nodes import GetAttr
 from ..subgraphs import Linear
 from ..targets import WeightOnlyGroupwiseQuantMatmulPlugin, WeightOnlyQuantMatmulPlugin
+from ..targets.weightonly_quantmatmul_plugin import WeightTypeId
 from .infra import NodewiseOptimizationPass, NodewisePassResult, ReplaceAllUses, propagate_metadata_from
 
 
@@ -112,7 +113,7 @@ class ReplaceMMByWoQGemmPlugin(NodewiseOptimizationPass):
                 assert len(plugin_inputs) == 3, "Zero point is not supported for weight-only quantization"
                 plugin = WeightOnlyQuantMatmulPlugin(
                     type_id=DataType(dequantize.target.dtype).to(trt.DataType),
-                    weight_type_id=1 if dequantize.target.bits == 8 else 2,
+                    weight_type_id=WeightTypeId.INT8 if dequantize.target.bits == 8 else WeightTypeId.INT4,
                 )
 
             plugin_node = node.graph.call_function(plugin, tuple(plugin_inputs))

--- a/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
+++ b/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
@@ -20,7 +20,6 @@ from tensorrt_llm.quantization import QuantAlgo
 from torch.fx import Node
 from transformers.utils.quantization_config import QuantizationMethod
 
-from ...quantization import inference_trtllm_quant_algo
 from ...types import DataType
 from ..nodes import GetAttr
 from ..subgraphs import Linear
@@ -75,20 +74,23 @@ class ReplaceMMByWoQGemmPlugin(NodewiseOptimizationPass):
             model_dtype=self.model_dtype,
         )
         with node.graph.inserting_before(unpacked_weight.node):
-            postprocessed_qweight = GetAttr.create(node.graph, unpacked_weight.name, postprocessed_qweight_tensor)
+            postprocessed_qweight = GetAttr.create(
+                node.graph, f"{unpacked_weight.name}_postprocessed", postprocessed_qweight_tensor
+            )
 
         plugin_inputs: list[Node] = [linear.input_node, postprocessed_qweight.node, scale.node]
 
         if zeros := GetAttr.specialize_from(dequantize.zeros) if dequantize.zeros is not None else None:
             postprocessed_zeros_tensor = postprocess_zeros_for_trtllm(
                 zeros.tensor,
-                dequantize.target.bits,
                 dequantize.target.global_quant_config.hf_quant_method,
                 scale=scale.tensor,
                 model_dtype=self.model_dtype,
             )
             with node.graph.inserting_before(zeros.node):
-                postprocessed_zeros = GetAttr.create(node.graph, zeros.name, postprocessed_zeros_tensor)
+                postprocessed_zeros = GetAttr.create(
+                    node.graph, f"{zeros.name}_postprocessed", postprocessed_zeros_tensor
+                )
                 plugin_inputs.append(postprocessed_zeros.node)
 
         with node.graph.inserting_before(node):
@@ -106,9 +108,10 @@ class ReplaceMMByWoQGemmPlugin(NodewiseOptimizationPass):
                     group_size=dequantize.target.group_size,
                 )
             else:
+                assert len(plugin_inputs) == 3, "Zero point is not supported for weight-only quantization"
                 plugin = WeightOnlyQuantMatmulPlugin(
                     type_id=DataType(dequantize.target.dtype).to(trt.DataType),
-                    weight_type_id=DataType(postprocessed_qweight_tensor.dtype).to(trt.DataType),
+                    weight_type_id=1 if dequantize.target.bits == 8 else 2,
                 )
 
             plugin_node = node.graph.call_function(plugin, tuple(plugin_inputs))
@@ -154,15 +157,19 @@ def postprocess_qweight_for_trtllm(
     Returns:
         torch.Tensor: The postprocessed weight tensor for TensorRT-LLM
     """
-    if quant_method in (QuantizationMethod.GPTQ, QuantizationMethod.AWQ):
+    if quant_method in (QuantizationMethod.AWQ, QuantizationMethod.GPTQ):
         assert qweight.dtype in (torch.uint8, torch.int8), f"Unsupported tensor dtype: {qweight.dtype=}"
-        assert bits in (4, 8), f"Unsupported GPTQ or AWQ bits: {bits=}"
+        assert bits in (4, 8), "Only 4-bit or 8-bit quantization is supported for TensorRT-LLM"
         if bits == 4:
             qweight = (qweight[:, 1::2] * 16 + qweight[:, ::2]).view(torch.int8)
         weight_dtype = torch.int8 if bits == 8 else torch.quint4x2
         qweight = torch.ops.trtllm.preprocess_weights_for_mixed_gemm(qweight, weight_dtype, torch.float16).view(
             model_dtype
         )
+    elif quant_method == QuantizationMethod.COMPRESSED_TENSORS:
+        assert bits == 8, "Only 8-bit quantization is supported for compressed tensors yet"
+        weight_dtype = torch.int8 if bits == 8 else torch.quint4x2
+        qweight = torch.ops.trtllm.preprocess_weights_for_mixed_gemm(qweight, weight_dtype, torch.float16)
     else:
         raise NotImplementedError(f"Unsupported quantization method: {quant_method}")
 
@@ -171,7 +178,6 @@ def postprocess_qweight_for_trtllm(
 
 def postprocess_zeros_for_trtllm(
     zeros: torch.Tensor,
-    bits: int,
     quant_method: QuantizationMethod,
     *,
     scale: torch.Tensor,
@@ -181,7 +187,6 @@ def postprocess_zeros_for_trtllm(
 
     Args:
         zeros (torch.Tensor): The quantized zero point tensor
-        bits (int): The number of bits used for quantization
         quant_method (QuantizationMethod): The quantization method used
         scale (torch.Tensor): The scale tensor
         model_dtype (torch.dtype): The model data type
@@ -189,11 +194,37 @@ def postprocess_zeros_for_trtllm(
     Returns:
         torch.Tensor: The postprocessed zero point tensor for TensorRT-LLM
     """
-    if quant_method in (QuantizationMethod.GPTQ, QuantizationMethod.AWQ):
-        assert bits in (4, 8), f"Unsupported GPTQ or AWQ bits: {bits=}"
+    if quant_method in (QuantizationMethod.AWQ, QuantizationMethod.COMPRESSED_TENSORS, QuantizationMethod.GPTQ):
         zeros = zeros * scale
         zeros = zeros.to(model_dtype)
     else:
         raise NotImplementedError(f"Unsupported quantization method: {quant_method}")
 
     return zeros
+
+
+def inference_trtllm_quant_algo(
+    bits: int, compute_dtype: torch.dtype, *, hf_quant_method: QuantizationMethod
+) -> QuantAlgo:
+    """Infer the quantization algorithm for TensorRT-LLM .
+
+    Args:
+        bits (int): The number of bits used for quantization
+        compute_dtype (torch.dtype): The compute data type
+        hf_quant_method (QuantizationMethod): The quantization method used by the Hugging Face model
+
+    Returns:
+        QuantAlgo: The quantization algorithm for TensorRT-LLM
+    """
+    assert bits in (4, 8), "Only 4-bit and 8-bit quantization is supported for TensorRT-LLM"
+    if hf_quant_method in (QuantizationMethod.AWQ, QuantizationMethod.COMPRESSED_TENSORS, QuantizationMethod.GPTQ):
+        quant_algo: str = f"W{bits}A{compute_dtype.itemsize * 8}"
+        if hf_quant_method == QuantizationMethod.GPTQ:
+            quant_algo = f"{quant_algo}_GPTQ"
+        elif hf_quant_method == QuantizationMethod.AWQ:
+            quant_algo = f"{quant_algo}_AWQ"
+    else:
+        raise RuntimeError(f"Unsupported quantization method: {hf_quant_method}")
+
+    assert quant_algo in QuantAlgo, f"Unsupported quantization algorithm: {quant_algo}"
+    return QuantAlgo[quant_algo]

--- a/src/ditto/fx/passes/wrap_weight_dequant_subgraphs.py
+++ b/src/ditto/fx/passes/wrap_weight_dequant_subgraphs.py
@@ -396,12 +396,13 @@ def unpack_qweight(qweight: torch.Tensor, bits: int, quant_method: QuantizationM
             )
             qweight = (qweight - 128).to(torch.int8)
     elif quant_method == QuantizationMethod.COMPRESSED_TENSORS:
-        original_shape = torch.Size([qweight.shape[0], qweight.shape[1] * (32 // bits)])
-        qweight = unpack_from_int32(qweight, bits, original_shape)
+        if qweight.dtype == torch.int32:
+            original_shape = torch.Size([qweight.shape[0], qweight.shape[1] * (32 // bits)])
+            qweight = unpack_from_int32(qweight, bits, original_shape)
 
-        if bits == 4:
-            qweight[qweight < 0] += 16
-            qweight = qweight.view(torch.uint8).contiguous()
+            if bits == 4:
+                qweight[qweight < 0] += 16
+                qweight = qweight.view(torch.uint8).contiguous()
     else:
         raise NotImplementedError(f"Unsupported quantization method: {quant_method}")
 

--- a/src/ditto/fx/targets/fake_quantizer.py
+++ b/src/ditto/fx/targets/fake_quantizer.py
@@ -15,7 +15,7 @@
 import torch
 from pydantic import Field
 
-from ...quantization import GlobalQuantConfig, QuantizeAlgorithm, QuantizeMode, QuantizeType
+from ...quantization import GlobalQuantConfig, QuantizeMode, QuantizeType
 from ...types import StrictlyTyped
 from .fake_tensor_mode import is_in_fake_tensor_mode
 
@@ -95,7 +95,6 @@ class Dequantizer(StrictlyTyped):
         output_shape (torch.Size): Shape of the output tensor
         bits (int): Number of bits for quantization
         mode (QuantizeMode): Mode of quantization
-        algorithm (QuantizeAlgorithm): Algorithm of quantization. Defaults to PTQ.
         group_size (int | None): Size of quantization groups. Defaults to None.
     """
 
@@ -104,7 +103,6 @@ class Dequantizer(StrictlyTyped):
     output_shape: torch.Size
     bits: int
     mode: QuantizeMode
-    algorithm: QuantizeAlgorithm = QuantizeAlgorithm.PTQ
     group_size: int | None = None
 
     @property

--- a/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
+++ b/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
@@ -25,11 +25,11 @@ class WeightOnlyQuantMatmulPlugin(Plugin):
     """TensorRT plugin for matrix multiplication with weight-only quantization.
 
     Attributes:
-        weight_type_id (trt.DataType): Type ID for weight tensor.
+        weight_type_id (int): Type ID for weight tensor (1: int8, 2: int4).
         type_id (trt.DataType): Data type for computation.
     """
 
-    weight_type_id: trt.DataType
+    weight_type_id: int
     type_id: trt.DataType
 
     def __call__(
@@ -51,7 +51,7 @@ class WeightOnlyQuantMatmulPlugin(Plugin):
             torch.Tensor: Result of matrix multiplication
         """
         if is_in_fake_tensor_mode():
-            return torch.zeros(x.shape[0], scale.shape[1], dtype=x.dtype)
+            return torch.zeros(x.shape[0], weight.shape[1], dtype=x.dtype)
         raise NotImplementedError(f"{type(self).__name__} doesn't have implementation")
 
 

--- a/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
+++ b/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
@@ -12,8 +12,10 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from enum import IntEnum
 from typing import Any
 
+import numpy as np
 import tensorrt as trt
 import torch
 
@@ -21,16 +23,43 @@ from .fake_tensor_mode import is_in_fake_tensor_mode
 from .plugin import Plugin
 
 
+class WeightTypeId(IntEnum):
+    """Type ID for weight tensor.
+
+    Attributes:
+        INT8 (int): Type ID for int8 weight tensor.
+        INT4 (int): Type ID for int4 weight tensor.
+    """
+
+    INT8 = 1
+    INT4 = 2
+
+
 class WeightOnlyQuantMatmulPlugin(Plugin):
     """TensorRT plugin for matrix multiplication with weight-only quantization.
 
     Attributes:
-        weight_type_id (int): Type ID for weight tensor (1: int8, 2: int4).
+        weight_type_id (WeightTypeId): Type ID for weight tensor.
         type_id (trt.DataType): Data type for computation.
     """
 
-    weight_type_id: int
+    weight_type_id: WeightTypeId
     type_id: trt.DataType
+
+    @classmethod
+    def get_field_dtype(cls, name: str, value: Any) -> type[np.number]:
+        """Get numpy dtype for a plugin field value.
+
+        Args:
+            name (str): Name of the field
+            value (Any): Value to get dtype for
+
+        Returns:
+            type[np.number]: numpy dtype for the value
+        """
+        if name == "weight_type_id":
+            return np.int32
+        return super().get_field_dtype(name, value)
 
     def __call__(
         self,

--- a/src/ditto/patches/__init__.py
+++ b/src/ditto/patches/__init__.py
@@ -18,6 +18,6 @@ from .torch import patch_modulelist_getitem
 from .transformers import patch_attention_mask_converter_make_causal_mask
 from .auto_awq import patch_wqlinear_mm_func_forward
 from .auto_gptq import patch_dynamically_import_quantlinear
-from .compressed_tensors import patch_decompress_weight
+from .compressed_tensors import patch_compressed_linear_process, patch_decompress_weight
 
 # Do NOT import from .trtllm! We don't want to apply the trtllm patches here.

--- a/src/ditto/patches/__init__.py
+++ b/src/ditto/patches/__init__.py
@@ -18,5 +18,6 @@ from .torch import patch_modulelist_getitem
 from .transformers import patch_attention_mask_converter_make_causal_mask
 from .auto_awq import patch_wqlinear_mm_func_forward
 from .auto_gptq import patch_dynamically_import_quantlinear
+from .compressed_tensors import patch_decompress_weight
 
 # Do NOT import from .trtllm! We don't want to apply the trtllm patches here.

--- a/src/ditto/patches/compressed_tensors.py
+++ b/src/ditto/patches/compressed_tensors.py
@@ -1,0 +1,50 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from compressed_tensors.compressors.quantized_compressors.pack_quantized import PackedQuantizationCompressor
+from compressed_tensors.quantization import QuantizationArgs
+from compressed_tensors.quantization.lifecycle.forward import dequantize
+
+from .patch import custom_patch
+
+
+@custom_patch(
+    name="compressed_tensors.compressors.quantized_compressors.pack_quantized.PackedQuantizationCompressor",
+    reason="",
+    required=True,
+    env_var_to_disable="DISABLE_COMPRESSED_TENSORS_PACKED_QUANTIZATION_COMPRESSOR_PATCH",
+)
+def patch_decompress_weight() -> None:
+    def patched_decompress_weight(
+        self,
+        compressed_data: dict[str, torch.Tensor],
+        quantization_args: QuantizationArgs | None = None,
+    ) -> torch.Tensor:
+        weight = compressed_data["weight_packed"]
+        scale = compressed_data["weight_scale"]
+        zero_point = compressed_data.get("weight_zero_point", None)
+        g_idx = compressed_data.get("weight_g_idx", None)
+        num_bits = quantization_args.num_bits
+
+        shifts = torch.arange(0, 32, num_bits, device=weight.device)
+        unpacked = torch.bitwise_right_shift(weight[:, :, None], shifts[None, None, :]).to(torch.int32)
+        unpacked = unpacked.view(unpacked.shape[0], -1) - (pow(2, num_bits) // 2)
+        unpacked = unpacked.to(torch.int8)
+
+        decompressed_weight = dequantize(x_q=unpacked, scale=scale, zero_point=zero_point, g_idx=g_idx)
+
+        return decompressed_weight
+
+    PackedQuantizationCompressor.decompress_weight = patched_decompress_weight

--- a/src/ditto/patches/compressed_tensors.py
+++ b/src/ditto/patches/compressed_tensors.py
@@ -14,15 +14,16 @@
 
 import torch
 from compressed_tensors.compressors.quantized_compressors.pack_quantized import PackedQuantizationCompressor
-from compressed_tensors.quantization import QuantizationArgs
-from compressed_tensors.quantization.lifecycle.forward import dequantize
+from compressed_tensors.linear.compressed_linear import CompressedLinear
+from compressed_tensors.quantization import QuantizationArgs, QuantizationStrategy
+from compressed_tensors.quantization.lifecycle import forward
 
 from .patch import custom_patch
 
 
 @custom_patch(
     name="compressed_tensors.compressors.quantized_compressors.pack_quantized.PackedQuantizationCompressor",
-    reason="",
+    reason="resolving torch.export error due to unsupported operation.",
     required=True,
     env_var_to_disable="DISABLE_COMPRESSED_TENSORS_PACKED_QUANTIZATION_COMPRESSOR_PATCH",
 )
@@ -42,9 +43,68 @@ def patch_decompress_weight() -> None:
         unpacked = torch.bitwise_right_shift(weight[:, :, None], shifts[None, None, :]).to(torch.int32)
         unpacked = unpacked.view(unpacked.shape[0], -1) - (pow(2, num_bits) // 2)
         unpacked = unpacked.to(torch.int8)
-
-        decompressed_weight = dequantize(x_q=unpacked, scale=scale, zero_point=zero_point, g_idx=g_idx)
+        decompressed_weight = forward.dequantize(x_q=unpacked, scale=scale, zero_point=zero_point, g_idx=g_idx)
 
         return decompressed_weight
 
     PackedQuantizationCompressor.decompress_weight = patched_decompress_weight
+
+
+@custom_patch(
+    name="compressed linear process",
+    reason="resolving torch.export error and the registration of the parameters during forward pass.",
+    required=True,
+    env_var_to_disable="DISABLE_COMPRESSED_TENSORS_COMPRESSED_LINEAR_PROCESS_PACH",
+)
+def patch_compressed_linear_process() -> None:
+    def patched_forward(self, input: torch.Tensor) -> torch.Tensor:
+        unpacked_weight = self.compressor.decompress_module(self)
+        return torch.nn.functional.linear(input, unpacked_weight, self.bias)
+
+    def patched_process_quantization(
+        x: torch.Tensor,
+        scale: torch.Tensor,
+        zero_point: torch.Tensor | None,
+        args: QuantizationArgs,
+        g_idx: torch.Tensor | None = None,
+        dtype: torch.dtype | None = None,
+        do_quantize: bool = True,
+        do_dequantize: bool = True,
+    ) -> torch.Tensor:
+        q_min, q_max = forward.calculate_range(args, x.device)
+        group_size = args.group_size
+
+        if args.strategy == QuantizationStrategy.GROUP:
+            while scale.ndim < 2:
+                # pad scale and zero point dims for slicing
+                scale = scale.unsqueeze(1)
+                zero_point = zero_point.unsqueeze(1) if zero_point is not None else None
+
+            assert g_idx is None or -1 in g_idx
+            assert zero_point is None, "zero point is not supported yet"
+            scale = scale.reshape(scale.shape[0], 1, -1)
+            output = x.reshape(x.shape[0], group_size, -1)
+
+            if do_dequantize:
+                output = forward._dequantize(output, scale, zero_point)
+
+            output = output.reshape(output.shape[0], output.shape[1] * output.shape[2])
+
+        else:  # covers channel, token and tensor strategies
+            if do_quantize:
+                output = forward._quantize(
+                    x,
+                    scale,
+                    zero_point,
+                    q_min,
+                    q_max,
+                    args,
+                    dtype=dtype,
+                )
+            if do_dequantize:
+                output = forward._dequantize(output if do_quantize else x, scale, zero_point)
+
+        return output
+
+    forward._process_quantization = patched_process_quantization
+    CompressedLinear.forward = patched_forward

--- a/src/ditto/quantization.py
+++ b/src/ditto/quantization.py
@@ -286,7 +286,8 @@ class GlobalQuantConfig(StrictlyTyped):
                 assert (
                     config.weights.strategy is not None
                     and config.weights.num_bits in (4, 8)
-                    and config.weights.strategy in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL)
+                    and config.weights.strategy
+                    in (QuantizationStrategy.TENSOR, QuantizationStrategy.CHANNEL, QuantizationStrategy.GROUP)
                 ), f"Unsupported weight quantization scheme: {config.weights}"
                 weight_quant_scheme = QuantScheme(
                     bits=config.weights.num_bits,
@@ -304,7 +305,7 @@ class GlobalQuantConfig(StrictlyTyped):
                 if weight_quant_scheme.type == QuantizeType.INT:
                     trtllm_quant_algo = QuantAlgo.W8A16 if weight_quant_scheme.bits == 8 else QuantAlgo.W4A16
                 else:
-                    raise NotImplementedError(f"Unsupported weight-only quantization mode: {weight_quant_scheme=}")
+                    raise NotImplementedError(f"Unsupported weight-only quantization type: {weight_quant_scheme.type=}")
             else:
                 assert (
                     quantize_type := input_quant_scheme.type


### PR DESCRIPTION
# Summary

- Support weight-only quantization (W4A16, W8A16) for `CompressedTensors` package
- Add some patches for resolving torch.export errors
- W8A16 for float type is not supported in WoQ plugins for TensorRT-LLM

# Tested Models

- nm-testing/tinyllama-oneshot-w8a16-per-channel
- neuralmagic/gemma-2-2b-it-quantized.w8a16
- nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A16-G128-compressed
- nm-testing/TinyLlama-1.1B-Chat-v1.0-W8A16_channel-e2e
- nm-testing/Qwen2-1.5B-Instruct-W8A16-Channelwise
- neuralmagic/Qwen2.5-0.5B-quantized.w8a16
- nm-testing/TinyLlama-1.1B-Chat-v1.0-W4A16-e2e
- neuralmagic/granite-3.1-2b-instruct-quantized.w4a16