### PR TITLE
feat: support modelopt (weight-only and fp8 quantization)

### DIFF
--- a/src/ditto/__main__.py
+++ b/src/ditto/__main__.py
@@ -19,6 +19,7 @@ import time
 from typing import Annotated, Literal
 
 import click
+import modelopt.torch.opt as mto
 import torch
 from loguru import logger
 from transformers import (
@@ -201,6 +202,7 @@ def build(
 
     with disable_torch_jit_state(), disable_modelopt_peft_patches():
         logger.info(f"Loading model {model_id}")
+        mto.enable_huggingface_checkpointing()
         model = AutoModelForCausalLM.from_pretrained(
             model_id,
             torch_dtype=get_model_dtype(dtype),

--- a/src/ditto/fx/passes/fuse_projections.py
+++ b/src/ditto/fx/passes/fuse_projections.py
@@ -83,11 +83,12 @@ class FuseProjections(NodewiseOptimizationPass):
             ]:
                 assert len(act_scales) == len(linears) and all(
                     act_scales[0].item() == act_scale.item() for act_scale in act_scales
-                )
-                assert (activation_quantization := linears[0].activation_quantization) is not None
+                ), "All scale values of target linear layers must be the same"
                 assert (
-                    activation_quantization.zero_point is None
-                ), "fusion of per-tensor activation quantization with zero point is not supported"
+                    activation_quantization := linears[0].activation_quantization
+                ) is not None and activation_quantization.zero_point is None, (
+                    "fusion of per-tensor activation quantization with zero point is not supported"
+                )
                 fused_node.meta[ACTIVATION_QUANTIZATION] = activation_quantization.model_copy()
 
             if all(linear.bias_node is not None for linear in linears):

--- a/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
+++ b/src/ditto/fx/passes/replace_mm_by_woq_gemm_plugin.py
@@ -168,7 +168,7 @@ def postprocess_qweight_for_trtllm(
         torch.Tensor: The postprocessed weight tensor for TensorRT-LLM
     """
     assert bits in (4, 8), "Only 4-bit or 8-bit quantization is supported for Weight-Only Quantization of TensorRT-LLM"
-    if quant_method in ("awq", "gptq", "compressed-tensors"):
+    if quant_method in ("awq", "gptq", "compressed-tensors", "modelopt"):
         assert qweight.dtype in (torch.uint8, torch.int8), f"Unsupported tensor dtype: {qweight.dtype=}"
         if bits == 4:
             qweight = (qweight[:, 1::2] * 16 + qweight[:, ::2]).view(torch.int8)
@@ -200,7 +200,7 @@ def postprocess_zeros_for_trtllm(
     Returns:
         torch.Tensor: The postprocessed zero point tensor for TensorRT-LLM
     """
-    if quant_method in ("awq", "compressed-tensors", "gptq"):
+    if quant_method in ("awq", "compressed-tensors", "gptq", "modelopt"):
         zeros = zeros * scale
         zeros = zeros.to(model_dtype)
     else:
@@ -221,7 +221,7 @@ def inference_trtllm_quant_algo(bits: int, compute_dtype: torch.dtype, *, quant_
         QuantAlgo: The quantization algorithm for TensorRT-LLM
     """
     assert bits in (4, 8), "Only 4-bit and 8-bit quantization is supported for TensorRT-LLM"
-    if quant_method in ("awq", "compressed-tensors", "gptq"):
+    if quant_method in ("awq", "compressed-tensors", "gptq", "modelopt"):
         quant_algo: str = f"W{bits}A{compute_dtype.itemsize * 8}"
         if quant_method == "gptq":
             quant_algo = f"{quant_algo}_GPTQ"

--- a/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
+++ b/src/ditto/fx/targets/weightonly_quantmatmul_plugin.py
@@ -80,7 +80,11 @@ class WeightOnlyQuantMatmulPlugin(Plugin):
             torch.Tensor: Result of matrix multiplication
         """
         if is_in_fake_tensor_mode():
-            return torch.zeros(x.shape[0], weight.shape[1], dtype=x.dtype)
+            return torch.zeros(
+                x.shape[0],
+                weight.shape[1] if self.weight_type_id == WeightTypeId.INT8 else weight.shape[1] * 2,
+                dtype=x.dtype,
+            )
         raise NotImplementedError(f"{type(self).__name__} doesn't have implementation")
 
 

--- a/src/ditto/patches/__init__.py
+++ b/src/ditto/patches/__init__.py
@@ -19,5 +19,6 @@ from .transformers import patch_attention_mask_converter_make_causal_mask
 from .auto_awq import patch_wqlinear_mm_func_forward
 from .auto_gptq import patch_dynamically_import_quantlinear
 from .compressed_tensors import patch_compressed_linear_process
+from .modelopt import patch_quantize_forward
 
 # Do NOT import from .trtllm! We don't want to apply the trtllm patches here.

--- a/src/ditto/patches/compressed_tensors.py
+++ b/src/ditto/patches/compressed_tensors.py
@@ -31,7 +31,7 @@ from .patch import custom_patch
     reason="resolving torch.export error and the registration of the parameters "
     "and applying custom fake quantize operation",
     required=True,
-    env_var_to_disable="DISABLE_COMPRESSED_TENSORS_COMPRESSED_LINEAR_PROCESS_PACH",
+    env_var_to_disable="DISABLE_COMPRESSED_TENSORS_COMPRESSED_LINEAR_PROCESS_PATCH",
 )
 def patch_compressed_linear_process() -> None:
     original_from_linear = CompressedLinear.from_linear

--- a/src/ditto/patches/modelopt.py
+++ b/src/ditto/patches/modelopt.py
@@ -32,8 +32,8 @@ def patch_quantize_forward() -> None:
                 inp,
                 8,
                 self.input_quantizer._dynamic,
-                self.scales.dtype,
-                self.scales if self.input_quantizer._dynamic is False else None,
+                self.input_scale.dtype,
+                self.input_scale if self.input_quantizer._dynamic is False else None,
             )
         if self.weight_quantizer.is_enabled:
             weight = ditto_dequantize(

--- a/src/ditto/patches/modelopt.py
+++ b/src/ditto/patches/modelopt.py
@@ -1,0 +1,53 @@
+# Copyright 2025 SqueezeBits, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import torch
+from modelopt.torch.quantization.nn.modules.quant_module import QuantLinearConvBase
+
+from ..custom_ops import ditto_dequantize
+from .patch import custom_patch
+
+
+@custom_patch(
+    name="modelopt.torch.quantization.nn.modules.quant_module.QuantLinearConvBase",
+    reason="applying custom dequantize operation",
+    required=True,
+    env_var_to_disable="DISABLE_MODELOPT_QUANT_LINEAR_CONV_BASE_PATCH",
+)
+def patch_quantize_forward() -> None:
+    def patched_forward(self: QuantLinearConvBase, inp: torch.Tensor, *args, **kwargs) -> torch.Tensor:
+        if self.input_quantizer.is_enabled:
+            inp = ditto_dequantize(
+                inp,
+                8,
+                self.input_quantizer._dynamic,
+                self.scales.dtype,
+                self.scales if self.input_quantizer._dynamic is False else None,
+            )
+        if self.weight_quantizer.is_enabled:
+            weight = ditto_dequantize(
+                self.unpacked_weight,
+                8 if self.weight_quantizer.num_bits == (4, 3) else self.weight_quantizer.num_bits,
+                self.weight_quantizer._dynamic,
+                self.scales.dtype,
+                self.scales,
+                self.unpacked_zeros,
+                self.weight_quantizer.block_sizes.get(-1, None) if self.weight_quantizer.block_sizes else None,
+            ).T
+        else:
+            weight = self.weight
+        out = torch.nn.functional.linear(inp, weight, self.bias if self.bias is not None else None)
+        return out
+
+    QuantLinearConvBase.forward = patched_forward

--- a/src/ditto/patches/modelopt.py
+++ b/src/ditto/patches/modelopt.py
@@ -15,7 +15,7 @@
 import torch
 from modelopt.torch.quantization.nn.modules.quant_module import QuantLinearConvBase
 
-from ..custom_ops import ditto_dequantize
+from ..custom_ops import ditto_fake_quantize
 from .patch import custom_patch
 
 
@@ -28,7 +28,7 @@ from .patch import custom_patch
 def patch_quantize_forward() -> None:
     def patched_forward(self: QuantLinearConvBase, inp: torch.Tensor, *args, **kwargs) -> torch.Tensor:
         if self.input_quantizer.is_enabled:
-            inp = ditto_dequantize(
+            inp = ditto_fake_quantize(
                 inp,
                 8,
                 self.input_quantizer._dynamic,
@@ -36,7 +36,7 @@ def patch_quantize_forward() -> None:
                 self.input_scale if self.input_quantizer._dynamic is False else None,
             )
         if self.weight_quantizer.is_enabled:
-            weight = ditto_dequantize(
+            weight = ditto_fake_quantize(
                 self.unpacked_weight,
                 8 if self.weight_quantizer.num_bits == (4, 3) else self.weight_quantizer.num_bits,
                 self.weight_quantizer._dynamic,
@@ -48,6 +48,16 @@ def patch_quantize_forward() -> None:
         else:
             weight = self.weight
         out = torch.nn.functional.linear(inp, weight, self.bias if self.bias is not None else None)
+
+        if self.output_quantizer.is_enabled:
+            out = ditto_fake_quantize(
+                out,
+                8 if self.output_quantizer.num_bits == (4, 3) else self.output_quantizer.num_bits,
+                self.output_quantizer._dynamic,
+                out.dtype,
+                self.output_scale if self.output_quantizer._dynamic is False else None,
+            )
+
         return out
 
     QuantLinearConvBase.forward = patched_forward

--- a/src/ditto/quantization.py
+++ b/src/ditto/quantization.py
@@ -21,6 +21,7 @@ from compressed_tensors.compressors.quantized_compressors.pack_quantized import 
 from compressed_tensors.linear.compressed_linear import CompressedLinear
 from compressed_tensors.quantization import QuantizationScheme, QuantizationStrategy, QuantizationType
 from loguru import logger
+from modelopt.torch.quantization.nn.modules.quant_linear import _QuantLinear as QuantLinear
 from peft import PeftModel
 from tensorrt_llm.quantization import QuantAlgo
 from tensorrt_llm.quantization.functional import unpack_int32_into_int8
@@ -163,18 +164,105 @@ class GlobalQuantConfig(StrictlyTyped):
     quant_configs: list[TargetQuantConfig] = []
 
     @classmethod
-    # pylint: disable-next=too-many-branches
-    def create_from(cls, pretrained_config: PretrainedConfig) -> Self | None:
+    # pylint: disable-next=too-many-branches, too-many-statements
+    def create_from(cls, model: PreTrainedModel | PeftModel) -> Self | None:
         """Create a GlobalQuantConfig from a pretrained config.
 
         Args:
-            pretrained_config (PretrainedConfig): The pretrained config
+            model (PreTrainedModel | PeftModel): The model to create the GlobalQuantConfig from
 
         Returns:
             Self | None: The created GlobalQuantConfig or None if no quantization config is found
         """
+        input_quant_scheme: QuantScheme | None = None
+        weight_quant_scheme: QuantScheme | None = None
+
+        if quant_linears := [module for _, module in model.named_modules() if isinstance(module, QuantLinear)]:
+            if quant_linears[0].input_quantizer.is_enabled:
+                assert (bits := quant_linears[0].input_quantizer.num_bits) == (
+                    4,
+                    3,
+                ), f"Unsupported bits for activation quantization: {bits=}"
+                assert (
+                    quant_linears[0].input_quantizer.axis is None or quant_linears[0].input_quantizer._dynamic
+                ), "Only per-tensor or per-token quantization is supported for activation quantization"
+                input_quant_scheme = QuantScheme(
+                    bits=8,
+                    mode=(
+                        QuantizeMode.PER_TOKEN if quant_linears[0].input_quantizer._dynamic else QuantizeMode.PER_TENSOR
+                    ),
+                    type=QuantizeType.FLOAT,
+                    has_zero_point=False,
+                    dynamic=quant_linears[0].input_quantizer._dynamic,
+                )
+
+            if quant_linears[0].weight_quantizer.is_enabled:
+                assert (bits := quant_linears[0].weight_quantizer.num_bits) in (
+                    4,
+                    8,
+                    (4, 3),
+                ), f"Unsupported bits for weight quantization: {bits=}"
+                weight_quant_scheme = QuantScheme(
+                    bits=8 if bits == (4, 3) else bits,
+                    mode=(
+                        QuantizeMode.PER_GROUP
+                        if quant_linears[0].weight_quantizer.block_sizes
+                        else QuantizeMode.PER_TENSOR
+                        if quant_linears[0].weight_quantizer.axis is None
+                        else QuantizeMode.PER_CHANNEL
+                    ),
+                    type=QuantizeType.FLOAT if bits == (4, 3) else QuantizeType.INT,
+                    group_size=quant_linears[0].weight_quantizer.block_sizes.get(-1, None)
+                    if quant_linears[0].weight_quantizer.block_sizes
+                    else None,
+                    has_zero_point=False,
+                    dynamic=quant_linears[0].weight_quantizer._dynamic,
+                )
+
+            assert weight_quant_scheme is not None, "Weight quantization scheme is required"
+
+            if input_quant_scheme is None:
+                if weight_quant_scheme.type == QuantizeType.INT:
+                    trtllm_quant_algo = QuantAlgo.W8A16 if weight_quant_scheme.bits == 8 else QuantAlgo.W4A16
+                else:
+                    raise NotImplementedError("Weight-only quantization for floating-point types is not supported")
+            else:
+                assert (
+                    quantize_type := input_quant_scheme.type
+                ) == weight_quant_scheme.type, "input and weight quantization type must be the same"
+                if quantize_type == QuantizeType.FLOAT:
+                    if (input_quant_scheme.mode, weight_quant_scheme.mode) == (
+                        QuantizeMode.PER_TENSOR,
+                        QuantizeMode.PER_TENSOR,
+                    ):
+                        trtllm_quant_algo = QuantAlgo.FP8
+                    elif (input_quant_scheme.mode, weight_quant_scheme.mode) == (
+                        QuantizeMode.PER_TOKEN,
+                        QuantizeMode.PER_CHANNEL,
+                    ):
+                        trtllm_quant_algo = QuantAlgo.FP8_PER_CHANNEL_PER_TOKEN
+                    else:
+                        raise NotImplementedError(
+                            f"Unsupported quantization mode: {input_quant_scheme.mode}, {weight_quant_scheme.mode}"
+                        )
+                else:
+                    raise NotImplementedError(f"Unsupported input/weight quantization type: {quantize_type=}")
+
+            return cls(
+                hf_quant_method="modelopt",
+                trtllm_quant_algo=trtllm_quant_algo,
+                quant_configs=[
+                    TargetQuantConfig(
+                        target=torch.ops.aten.mm.default,
+                        input_quant_scheme=input_quant_scheme,
+                        weight_quant_scheme=weight_quant_scheme,
+                    ),
+                ],
+            )
+
         if not (
-            (quantization_config := getattr(pretrained_config, "quantization_config", None)) is not None
+            isinstance(pretrained_config := model.config, PretrainedConfig)
+            and (quantization_config := getattr(pretrained_config, "quantization_config", None)) is not None
             and isinstance(quantization_config, QuantizationConfigMixin)
         ):
             return None
@@ -234,7 +322,6 @@ class GlobalQuantConfig(StrictlyTyped):
                 "Linear"
             ], f'Unsupported targets: {config.targets=}. Currently, only a single "Linear" target is supported.'
 
-            input_quant_scheme: QuantScheme | None = None
             if config.input_activations is not None:
                 assert (
                     config.input_activations.strategy is not None
@@ -247,7 +334,7 @@ class GlobalQuantConfig(StrictlyTyped):
                     type=QuantizeType.from_quant_type(config.input_activations.type),
                     dynamic=config.input_activations.dynamic,
                 )
-            weight_quant_scheme: QuantScheme | None = None
+
             if config.weights is not None:
                 assert (
                     config.weights.strategy is not None
@@ -365,6 +452,65 @@ def preprocess_qlinear_module(model: PreTrainedModel | PeftModel, global_quant_c
                 "scales", weight_scale.T.contiguous() if module.quantization_scheme.weights.group_size else weight_scale
             )
             del module.weight_scale
+
+        elif isinstance(module, QuantLinear):
+            if module.weight_quantizer.is_enabled:
+                weight, scale = export_modelopt_weight_and_scale(module)
+                module.register_buffer("unpacked_weight", weight)
+                module.register_buffer("unpacked_zeros", None)
+                module.register_buffer("scales", scale)
+                del module.weight
+
+
+def export_modelopt_weight_and_scale(module: QuantLinear) -> tuple[torch.Tensor, torch.Tensor]:
+    """Export the weight and scale of the QuantLinear module for ModelOpt.
+
+    Args:
+        module (QuantLinear): The QuantLinear module to export
+
+    Returns:
+        tuple[torch.Tensor, torch.Tensor]: The unpacked weight and scale
+    """
+    assert (
+        hasattr(module, "weight")
+        and isinstance(module.weight, torch.nn.Parameter)
+        and isinstance(weight := module.weight.data, torch.Tensor)
+        and isinstance(amax := module.weight_quantizer.amax, torch.Tensor)
+    )
+    if module.weight_quantizer.num_bits in (4, 8):
+        maxbound = torch.tensor(
+            [(1 << (module.weight_quantizer.num_bits - 1 + int(module.weight_quantizer.unsigned))) - 1]
+        )
+        scale = (amax.float() / maxbound.to(amax.device)).to(amax.dtype)
+
+        if module.weight_quantizer.block_sizes:
+            assert (block_size := module.weight_quantizer.block_sizes.get(-1, None)) is not None
+            scale = scale.reshape(-1, weight.shape[-1] // block_size)
+            weight = (
+                (weight / scale[..., :, torch.arange(weight.shape[-1]) // block_size])
+                .round()
+                .clamp(-maxbound.item() - 1, maxbound.item())
+                .to(torch.int8)
+            )
+            scale = scale.T
+        else:
+            weight = (weight / scale).round().clamp(-maxbound.item() - 1, maxbound.item()).to(torch.int8)
+            if scale.ndim == 1 and scale.numel() == 1:  # convert per-tensor to per-channel
+                logger.warning(
+                    "Converting per-tensor scale to per-channel scale, which might cause performance degradation."
+                )
+                scale = scale.expand(weight.shape[0], 1)
+
+    else:
+        maxbound = torch.tensor(448.0)
+        scale = (amax.float() / maxbound.to(amax.device)).to(amax.dtype)
+        weight = (weight / scale).to(torch.float8_e4m3fn)
+
+    if module.weight_quantizer.num_bits == 4:
+        weight[weight < 0] += 16
+        weight = weight.view(torch.uint8)
+
+    return weight.T.contiguous(), scale.contiguous()
 
 
 def unpack_qweight(qweight: torch.Tensor, bits: int, quant_method: QuantizeMethod) -> torch.Tensor:


### PR DESCRIPTION
# Summary

- Added the patch for `ModelOpt`
- Added `mto.enable_huggingface_checkpointing()` and `mtq.utils.export_torch_model()` when loading and exporting a model
- Updated logic to extract `ModelOpt` configuration from the model
- Fixed a parallelization issue due to the introduction of `torch.ops.ditto.fake_quantize`

# Misc

- Currently, only pre-trained models saved using the `save_pretrained` method are supported. Do not use `export_tensorrt_llm_checkpoint`.
- TensorRT-LLM doesn't support per-tensor weight-only quantization. However, ditto supports it by broadening the per-tensor scale into a per-channel scale.