### PR TITLE
feat: support kv cache quantization for compressed-tensors

### DIFF
--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -65,10 +65,10 @@ main() {
         'RedHatAI/Llama-3.2-1B-Instruct-FP8-dynamic --ckpt-args "--use_fp8_rowwise"'
         'nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-Dynamic-compressed --ckpt-args "--use_fp8_rowwise"'
         'nm-testing/Mistral-7B-Instruct-v0.3-FP8-Dynamic --model-type llama --ckpt-args "--use_fp8_rowwise"'
-        'RedHatAI/Qwen2.5-0.5B-FP8-dynamic --skip-native --print-output'
+        # 'RedHatAI/Qwen2.5-0.5B-FP8-dynamic --skip-native --print-output'
         # KV cache quantization (compressed-tensor)
-        'RedHatAI/Phi-3.5-mini-instruct-FP8-KV --skip-native --print-output'
-        'nm-testing/Llama-3.2-1B-Instruct-FP8-KV --skip-native --print-output'
+        'RedHatAI/Phi-3.5-mini-instruct-FP8-KV --skip-native --print-output --no-use-paged-context-fmha'
+        'nm-testing/Llama-3.2-1B-Instruct-FP8-KV --skip-native --print-output --no-use-paged-context-fmha'
     )
 
     for MODEL_SPECIFIC_ARG in "${MODEL_SPECIFIC_ARGS[@]}"; do

--- a/scripts/test.sh
+++ b/scripts/test.sh
@@ -56,8 +56,8 @@ main() {
         # 'fbaldassarri/TinyLlama_TinyLlama_v1.1-autogptq-int8-gs128-sym --dtype float16 --skip-native --print-output'
         # 'fbaldassarri/TinyLlama_TinyLlama_v1.1-autogptq-int8-gs128-asym --dtype float16 --skip-native --print-output'
         # FP8 per-tensor quantization (compressed-tensor)
-        'RedHatAI/Llama-3.2-1B-Instruct-FP8 --ckpt-args "--use_fp8"  --build-args "--gemm_plugin fp8"'
-        'nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e --ckpt-args "--use_fp8"  --build-args "--gemm_plugin fp8"'
+        'RedHatAI/Llama-3.2-1B-Instruct-FP8 --ckpt-args "--use_fp8" --build-args "--gemm_plugin fp8"'
+        'nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-e2e --ckpt-args "--use_fp8" --build-args "--gemm_plugin fp8"'
         # 'RedHatAI/gemma-2-2b-it-FP8 --skip-native --print-output'
         # 'RedHatAI/starcoder2-3b-FP8 --skip-native --print-output'
         # 'nm-testing/Phi-3-mini-128k-instruct-FP8 --skip-native --print-output'
@@ -65,7 +65,10 @@ main() {
         'RedHatAI/Llama-3.2-1B-Instruct-FP8-dynamic --ckpt-args "--use_fp8_rowwise"'
         'nm-testing/TinyLlama-1.1B-Chat-v1.0-FP8-Dynamic-compressed --ckpt-args "--use_fp8_rowwise"'
         'nm-testing/Mistral-7B-Instruct-v0.3-FP8-Dynamic --model-type llama --ckpt-args "--use_fp8_rowwise"'
-        # 'RedHatAI/Qwen2.5-0.5B-FP8-dynamic --skip-native --print-output'
+        'RedHatAI/Qwen2.5-0.5B-FP8-dynamic --skip-native --print-output'
+        # KV cache quantization (compressed-tensor)
+        'RedHatAI/Phi-3.5-mini-instruct-FP8-KV --skip-native --print-output'
+        'nm-testing/Llama-3.2-1B-Instruct-FP8-KV --skip-native --print-output'
     )
 
     for MODEL_SPECIFIC_ARG in "${MODEL_SPECIFIC_ARGS[@]}"; do

--- a/src/ditto/api.py
+++ b/src/ditto/api.py
@@ -45,7 +45,7 @@ from .fx import generate_trtllm_engine_config
 from .fx.utils import find_output_node
 from .inline import inline
 from .literals import DTypeLiteral
-from .quantization import GlobalQuantConfig, preprocess_qlinear_module
+from .quantization import GlobalQuantConfig, preprocess_qlinear_module, update_kv_cache_scales
 from .transform import transform
 from .types import BuiltInConstant, verify
 
@@ -134,7 +134,9 @@ def trtllm_build(
     )
 
     if (global_quant_config := GlobalQuantConfig.create_from(model)) is not None:
-        preprocess_qlinear_module(model, global_quant_config)
+        preprocess_qlinear_module(model, global_quant_config.quant_method)
+        update_kv_cache_scales(model, global_quant_config.quant_method, global_quant_config.trtllm_kv_cache_quant_algo)
+
     if (
         global_quant_config is not None
         and global_quant_config.trtllm_kv_cache_quant_algo in (QuantAlgo.INT8, QuantAlgo.FP8)

--- a/src/ditto/fx/passes/fuse_projections.py
+++ b/src/ditto/fx/passes/fuse_projections.py
@@ -94,9 +94,10 @@ class FuseProjections(NodewiseOptimizationPass):
 
             if output_quantizations := [linear.output_quantization for linear in linears if linear.output_quantization]:
                 assert self.fused_lora_prefix == "attn_qkv"
-                assert len(output_quantizations) == len(
-                    linears
-                ), "All output quantizations for Q, K, and V must be provided"
+                assert len(output_quantizations) in (
+                    len(linears),
+                    len(linears) - 1,
+                ), "Output quantizations for K and V must be provided"
                 fused_node.meta[OUTPUT_QUANTIZATION] = max(output_quantizations, key=lambda q: q.scale.item())
 
             if all(linear.bias_node is not None for linear in linears):

--- a/src/ditto/quantization.py
+++ b/src/ditto/quantization.py
@@ -437,7 +437,9 @@ def create_fake_quant_linear(module: _QuantLinear) -> QuantLinear:
             weight=weight,
             num_bits=8 if module.weight_quantizer.num_bits == (4, 3) else module.weight_quantizer.num_bits,
             dynamic=module.weight_quantizer._dynamic,
-            block_size=module.weight_quantizer.block_sizes.get(-1, None),
+            block_size=module.weight_quantizer.block_sizes.get(-1, None)
+            if module.weight_quantizer.block_sizes is not None
+            else None,
             scale=scale,
             zero_point=None,
         )

--- a/src/ditto/quantization.py
+++ b/src/ditto/quantization.py
@@ -463,7 +463,7 @@ def create_fake_quant_linear(module: _QuantLinear) -> QuantLinear:
         )
 
     if module.output_quantizer.is_enabled:
-        assert module.output_quantizer._dynamic is True, "Dynamic output quantization is not supported"
+        assert module.output_quantizer._dynamic is False, "Dynamic output quantization is not supported"
         assert (
             isinstance(amax := module.output_quantizer.amax, torch.Tensor) and amax.numel() == 1
         ), "Only per-tensor quantization for output is supported"


### PR DESCRIPTION
This PR introduces support for **KV cache quantization** using `compressed-tensors`.

- Updated some patches for `compressed-tensors`
  - Patched `CompressedLinear.forward()` to support output scaling
  - Wrapped `quantization.apply_quantization_config` to detect KV cache targets in attention modules and initialize KV cache output scales (`k_scale`, `v_scale`) via `_initialize_attn_scales`
- Extended `GlobalQuantConfig.create_from()` to support kv cache quantization for `compressed-tensors`
- Introduced `update_kv_cache_scales()` to propagate `k_scale` and `v_scale` to `k_proj`, `v_proj`, or `qkv_proj` modules by registering them as `output_scale` buffers
- Updated test scripts
- Fixed minor issues