### PR TITLE
fix: change the shape of lora weight's tensor

### DIFF
--- a/src/ditto/fx/targets/lora_plugin.py
+++ b/src/ditto/fx/targets/lora_plugin.py
@@ -243,7 +243,7 @@ class LoraPluginInputPair(StrictlyTyped):
             weights_pointers = Placeholder.create(
                 graph,
                 f"{prefix}_lora_weights_pointers_{layer_idx}",
-                hint=(weights_pointer_hint := TensorTypeHint(dtype=torch.int64, shape=(batch_size, 2))),
+                hint=(weights_pointer_hint := TensorTypeHint(dtype=torch.int64, shape=(batch_size, 3))),
             )
             ranks = Placeholder.create(
                 graph,


### PR DESCRIPTION
### Summary

- Changed the shape of lora weight's tensor (`lora_weight_pointers`) from (batch_size, 2) to (batch_size, 3)
  (refers to [link](https://github.com/NVIDIA/TensorRT-LLM/blob/6c3210a8becafe3449d65ca4e00b3b675962d955/tensorrt_llm/functional.py#L6642-L6643))