### PR TITLE
Support MoE models in TRTLLM v0.19.0

### DIFF
--- a/src/ditto/api.py
+++ b/src/ditto/api.py
@@ -323,8 +323,9 @@ def save_component(
 
     if isinstance(component, TRTLLMEngineConfig):
         logger.info(f"Writing engine config at {component_path}")
+        exclude = {"pretrained_config": {"moe"}} if component.pretrained_config.moe is None else None
         with open(component_path, "w") as f:
-            f.write(component.model_dump_json(indent=2))
+            f.write(component.model_dump_json(indent=2, exclude=exclude))
     elif isinstance(component, LoraConfig):
         logger.info(f"Writing lora config at {component_path}")
         component.save_pretrained(os.path.dirname(component_path))
@@ -366,7 +367,7 @@ def add_outputs(names: list[str]) -> Callable[[GraphModule], GraphModule]:
         node = find_output_node(gm)
 
         try:
-            outputs = node.args[0] + tuple(nodes[name] for name in names)
+            outputs = node.args[0] + tuple(nodes[name] for name in names)  # type: ignore
         except KeyError as e:
             gm.print_readable()
             raise RuntimeError(f"Failed to find all of the extra output nodes: {', '.join(names)}") from e

--- a/src/ditto/configs/trtllm/pretrained.py
+++ b/src/ditto/configs/trtllm/pretrained.py
@@ -461,7 +461,7 @@ class TRTLLMPretrainedConfig(StrictlyTyped):
     intermediate_size: int
     mapping: TRTLLMMapping = Field(default_factory=TRTLLMMapping)
     quantization: TRTLLMQuantConfig | None = None
-    moe: TRTLLMMoEConfig | None = Field(default=None, exclude=lambda v: v is None)
+    moe: TRTLLMMoEConfig | None = None
     extra_fields: dict[str, Any] = Field(default_factory=dict, exclude=True)
 
     @model_serializer(mode="wrap")

--- a/src/ditto/fx/passes/replace_moe_by_mixture_of_experts_plugin.py
+++ b/src/ditto/fx/passes/replace_moe_by_mixture_of_experts_plugin.py
@@ -23,9 +23,8 @@ from ..targets import (
     MixtureOfExpertsPlugin,
     MixtureOfExpertsPluginInputs,
     get_moe_activation_type,
-    get_moe_normalization_mode,
 )
-from .infra import NodewiseOptimizationPass, NodewisePassResult, ReplaceAllUses, get_pretrained_config
+from .infra import NodewiseOptimizationPass, NodewisePassResult, ReplaceAllUses
 
 
 class ReplaceMoEByMoEPlugin(NodewiseOptimizationPass):
@@ -56,7 +55,6 @@ class ReplaceMoEByMoEPlugin(NodewiseOptimizationPass):
             return {}
 
         graph = node.graph
-        pretrained_config = get_pretrained_config(graph)
 
         moe_plugin = MixtureOfExpertsPlugin(
             number_of_experts=moe.number_of_experts,
@@ -107,5 +105,5 @@ class ReplaceMoEByMoEPlugin(NodewiseOptimizationPass):
             graph_module.meta[MOE_CONFIG] = {
                 "num_experts": self.plugin.number_of_experts,
                 "shared_expert_intermediate_size": self.plugin._shared_expert_intermediate_size,
-                "experts_per_token": self.plugin.experts_per_token,
+                "top_k": self.plugin.experts_per_token,
             }

--- a/src/ditto/fx/passes/replace_moe_by_mixture_of_experts_plugin.py
+++ b/src/ditto/fx/passes/replace_moe_by_mixture_of_experts_plugin.py
@@ -60,16 +60,16 @@ class ReplaceMoEByMoEPlugin(NodewiseOptimizationPass):
 
         moe_plugin = MixtureOfExpertsPlugin(
             number_of_experts=moe.number_of_experts,
-            top_k=moe.top_k,
+            experts_per_token=moe.top_k,
             expert_hidden_size=moe.expert_hidden_size,
             expert_inter_size=moe.expert_inter_size,
-            normalization_mode=get_moe_normalization_mode(pretrained_config),
             activation_type=get_moe_activation_type(),
             type_id=DataType(self.dtype).to(trt.DataType),
             weight_type_id=DataType(self.dtype).to(trt.DataType),
-            output_type_id=DataType(self.dtype).to(trt.DataType),
+            use_final_scales=moe.token_scores is not None,
             tp_size=self.tp_size,
             tp_rank=self.tp_rank,
+            use_lora=False,
         )
         moe_plugin._shared_expert_intermediate_size = moe.shared_expert_intermediate_size
         if self.plugin is None:
@@ -107,7 +107,5 @@ class ReplaceMoEByMoEPlugin(NodewiseOptimizationPass):
             graph_module.meta[MOE_CONFIG] = {
                 "num_experts": self.plugin.number_of_experts,
                 "shared_expert_intermediate_size": self.plugin._shared_expert_intermediate_size,
-                "top_k": self.plugin.top_k,
-                "normalization_mode": self.plugin.normalization_mode,
-                "sparse_mixer_epsilon": self.plugin.sparse_mixer_epsilon,
+                "experts_per_token": self.plugin.experts_per_token,
             }

--- a/src/ditto/fx/targets/__init__.py
+++ b/src/ditto/fx/targets/__init__.py
@@ -35,7 +35,6 @@ from .mixture_of_experts_plugin import (
     MixtureOfExpertsPlugin,
     MixtureOfExpertsPluginInputs,
     get_moe_activation_type,
-    get_moe_normalization_mode,
 )
 from .plugin import Plugin
 from .quantize_per_token import QuantizePerTokenPlugin


### PR DESCRIPTION
MoE plugin has changed to use `TopkLastDimPlugin` for topk operations outside of MoE plugin, which was formerly performed inside the MoE plugin. Currently supports Qwen2,3-MoE, DeepSeek-V1, Mixtral.
- Fixed changed arguments for the plugin
- Modify `CastRouterToFP32` pass to keep FP32 precision for router logits
- Generalize `TopkLastDimPlugin` replacement to greedy topk
- Properly remove moe config in the result config when it's null to prevent a runtime error.